### PR TITLE
docs: リポジトリ内 README を全面刷新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,103 @@
-# TRViS_TimetableServer
+# TRViS Timetable Server
+
+[TRViS](https://github.com/TetsuOtter/TRViS) 用の時刻表データを管理する Web アプリケーション一式です。
+時刻表データを編集する Web フロントエンドと、それを保存・配信する REST API バックエンドを、
+Docker Compose で一括起動できる形にまとめています。
+
+## 構成
+
+```text
+ブラウザ ──▶ proxy (nginx :80)
+                ├─ /      ──▶ front  (React + Vite を Apache httpd で配信)
+                └─ /api/  ──▶ php    (PHP 8.2 / Slim 4 の REST API)
+                                       ├─ mysql     (MySQL 8.0)
+                                       └─ firebase  (Firebase Auth Emulator)
+```
+
+| サービス     | コンテナ名           | 役割                                   | 公開ポート          |
+| ------------ | -------------------- | -------------------------------------- | ------------------- |
+| `proxy`      | `webmon-proxy`       | nginx リバースプロキシ（入口）         | `80`                |
+| `front`      | `webmon-front`       | フロントエンド（ビルド済み静的配信）   | （proxy 経由）      |
+| `php`        | `webmon-php`         | バックエンド API                       | `8080`（直接アクセス用） |
+| `mysql`      | `webmon-db`          | データベース                           | （内部ネットワーク） |
+| `firebase`   | `webmon-firebase`    | 認証エミュレータ                       | `9099` / `4000`（UI） |
+| `phpmyadmin` | `webmon-phpmyadmin`  | DB 管理 UI                             | `81`                |
+
+通常のアクセスはすべて `proxy`（`http://localhost/`）経由です。
+`php` の `8080` はプロキシを介さず API を直接叩きたいときのための補助ポートです。
+
+## ディレクトリ構成
+
+| パス          | 内容                                                                 |
+| ------------- | -------------------------------------------------------------------- |
+| `api_defs/`   | OpenAPI 仕様（API 契約の source-of-truth）。ここからコードを生成する  |
+| `backend/`    | PHP / Slim 4 製の REST API。`api_defs` から雛形を生成し実装を肉付け   |
+| `frontend/`   | React + Vite + TypeScript の時刻表エディタ                           |
+| `mysql/`      | MySQL の初期スキーマ・設定・ログ                                      |
+| `firebase/`   | Firebase Auth Emulator のイメージと設定                              |
+| `proxy/`      | nginx リバースプロキシの設定                                          |
+| `backend-logs/` | `php` コンテナの Apache ログのバインド先                            |
+
+各ディレクトリの詳細は、それぞれの `README.md` を参照してください。
+
+## クイックスタート（Docker Compose）
+
+1. 環境ファイルを用意する
+
+   ```sh
+   # MySQL の認証情報
+   cp mysql/.env.sample mysql/.env
+
+   # フロントエンドの環境変数（Firebase 設定等）
+   cp frontend/.env.sample frontend/.env
+
+   # バックエンドの Docker 用設定（DB / Firebase Emulator のホスト名を含む）
+   cp backend/config/prod/config.docker.inc.php backend/config/prod/config.inc.php
+   ```
+
+   `backend/config/prod/config.inc.php` は Git 管理外（開発者ごとのローカル設定）です。
+   詳細は [`backend/README.md`](backend/README.md) を参照してください。
+
+2. スタックを起動する
+
+   ```sh
+   docker compose up -d --build
+   ```
+
+3. アクセスする
+
+   - アプリ本体: <http://localhost/>
+   - API（直接）: <http://localhost:8080/api/v1/>
+   - phpMyAdmin: <http://localhost:81/>
+   - Firebase Emulator UI: <http://localhost:4000/>
+
+特定のサービスだけ作り直したいときは `./_restart.sh <service名>`（例: `./_restart.sh php`）が使えます。
+
+## 開発用補助スクリプト
+
+| スクリプト       | 用途                                                                 |
+| ---------------- | -------------------------------------------------------------------- |
+| `_php.sh`        | `backend/` をホスト PHP の組み込みサーバ（`localhost:8888`）で起動    |
+| `_mysql.sh`      | `webmon-db` コンテナ内の `mysql` クライアントへ接続                   |
+| `_restart.sh <s>` | Compose サービス `<s>` を停止・再ビルド・再起動                      |
+
+## API
+
+- ベース URL: `/api/v1`（本番は `https://trvis.t0r.dev/api/v1`）
+- 認証: Firebase が発行する ID トークンを `Authorization: Bearer <token>` で送る
+- 認証は「リクエストをゲートする」のではなく「権限でフィルタする」方式です。
+  未認証でも参照系は通り、その利用者が見える範囲（=匿名なら空）だけが返ります。
+  作成・更新・削除はトークン必須です。詳細は [`backend/README.md`](backend/README.md)。
+
+API 仕様は [`api_defs/`](api_defs/README.md) の OpenAPI 定義が正です。
+
+## CI
+
+GitHub Actions でマージゲートを構成しています。
+
+- `.github/workflows/backend-tests.yml` — PHP 8.2 + MySQL 8.0 で PHPUnit（実 DB 統合テスト含む）
+- `.github/workflows/frontend-tests.yml` — `trvis-api` 生成クライアントのビルド → `tsc` → `vite build`
+
+## ライセンス
+
+[MIT License](LICENSE)

--- a/api_defs/README.md
+++ b/api_defs/README.md
@@ -1,6 +1,57 @@
-# TRViS 時刻表管理用API
+# TRViS Timetable Server — API 定義（OpenAPI）
+
+[TRViS](https://github.com/TetsuOtter/TRViS) 時刻表管理 API の **仕様の source-of-truth** です。
+ここの OpenAPI 定義からバックエンド（PHP/Slim 4）とフロントエンドの API クライアントを
+コード生成します。API を変えるときは、まずここを編集します。
 
 ## 構想
 
-面倒なので、テーブルごとにAPIを作る。
+面倒なので、テーブルごとに API を作る。
 配列形式で入力させることで、複数のデータを一度に登録できるようにする。
+
+この方針は現在も有効です。各エンティティ（Project / WorkGroup / Line / Station /
+StopPattern / Work / Train / TimetableRow など）に対し CRUD エンドポイントを用意し、
+作成・更新系は配列を受け取って一括処理できる形にしています。
+
+## ファイル構成
+
+| パス                  | 内容                                                                        |
+| --------------------- | --------------------------------------------------------------------------- |
+| `api_root.yaml`       | ルート定義（info / servers / tags、各 path・object への参照）               |
+| `paths/`              | エンドポイント定義（エンティティごとにディレクトリ）                        |
+| `objects/`            | スキーマ定義（`Project.yaml`, `Line.yaml`, `StopPattern.yaml` …）           |
+| `parameters/`         | 共通パラメータ定義                                                          |
+| `response_objs/`      | 共通レスポンス定義                                                          |
+| `openapi.bundle.yml`  | 上記を 1 ファイルに束ねた生成物（**Git 管理外**。`bundle.sh` で再生成）     |
+| `php-slim4.config.yaml` | バックエンド生成設定（`php-slim4` ジェネレータ）                          |
+| `ts-fetch.config.yaml`  | フロントエンド生成設定（`typescript-fetch` ジェネレータ）                 |
+
+サーバ定義は 3 つ: ローカル Docker（`localhost:8080/api/v1`）、
+ローカルホスト実行（`localhost:8888/api/v1`）、本番（`https://trvis.t0r.dev/api/v1`）。
+
+## コード生成ワークフロー
+
+分割した定義を 1 ファイルにバンドルしてから、各言語のクライアント／サーバを生成します。
+
+```sh
+./bundle.sh        # redocly bundle api_root.yaml -o openapi.bundle.yml
+./gen_php.sh       # → ../backend     (php-slim4)
+./gen_ts.sh        # → ../frontend/packages/trvis-api (typescript-fetch)
+```
+
+- `bundle.sh` には [Redocly CLI](https://redocly.com/docs/cli/)、
+  `gen_*.sh` には [OpenAPI Generator CLI](https://openapi-generator.tech/) が必要です。
+- 生成器のバージョンはリポジトリルートの `openapitools.json` で **7.2.0** に固定しています
+  （生成済みコード側の `.openapi-generator/VERSION` も 7.2.0）。
+  こちらが正です。`api_defs/openapitools.json` には別の値が書かれていますが、
+  ルートの設定が優先されます（この不整合の修正はこのドキュメントの対象外）。
+
+### 生成先で手書きを残すには
+
+生成は出力先ディレクトリを上書きします。手書きで残したいファイルは、各生成先の
+`.openapi-generator-ignore` に列挙してください（バックエンドの `src/`・`config/`・
+`composer.json`・`README.md` などは ignore 済み）。詳細は
+[`../backend/README.md`](../backend/README.md) を参照。
+
+データモデル（テーブル）側の詳細は [`../mysql/README.md`](../mysql/README.md)、
+全体構成はリポジトリルートの [`README.md`](../README.md) を参照してください。

--- a/backend/.openapi-generator-ignore
+++ b/backend/.openapi-generator-ignore
@@ -1,5 +1,6 @@
 .github/
 composer.json
+README.md
 /.gitignore
 public/index.php
 config/

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,282 +1,121 @@
-# trvis_backend\main - PHP Slim 4 Server library for TRViS用 時刻表管理用API
+# TRViS Timetable Server — Backend
 
-* [OpenAPI Generator](https://openapi-generator.tech)
-* [Slim 4 Documentation](https://www.slimframework.com/docs/v4/)
+[TRViS](https://github.com/TetsuOtter/TRViS) 用の時刻表データを保存・配信する REST API です。
+PHP 8.2 / [Slim 4](https://www.slimframework.com/) + [PHP-DI](https://php-di.org/) で実装しています。
 
-This server has been generated with [Slim PSR-7](https://github.com/slimphp/Slim-Psr7) implementation.
-[PHP-DI](https://php-di.org/doc/frameworks/slim.html) package used as dependency container.
+API 仕様の source-of-truth は [`../api_defs/`](../api_defs/README.md) の OpenAPI 定義です。
+このディレクトリのコードは、その定義から OpenAPI Generator（`php-slim4`）で生成した雛形に、
+手書きの実装を肉付けする構成になっています。
 
-## Requirements
+## ディレクトリ構成
 
-* Web server with URL rewriting
-* PHP 7.4 or newer
+| パス                  | 内容                                                                              | 生成 / 手書き |
+| --------------------- | --------------------------------------------------------------------------------- | ------------- |
+| `lib/`                | OpenAPI Generator が生成するモデル・抽象クラス・ルーティング登録                   | 生成（原則編集しない） |
+| `src/trvis_backend/`  | 手書きの実装本体                                                                  | 手書き        |
+| `public/index.php`    | エントリポイント（コンテナ構築・ミドルウェア・ルーティング起動）                  | 生成（ignore 済み） |
+| `config/`             | 環境別設定（後述）                                                                | 手書き        |
+| `tests/`              | PHPUnit テスト（`Api/` `Model/` `Integration/`）                                  | 手書き        |
+| `scripts/`            | 補助スクリプト                                                                    | 手書き        |
+| `logs/`               | アプリ／Apache ログ出力先                                                          | —             |
+| `Dockerfile`          | `php:8.2-apache` ベース。ドキュメントルートは `public/`                            | 手書き        |
 
-This package contains `.htaccess` for Apache configuration.
-If you use another server(Nginx, HHVM, IIS, lighttpd) check out [Web Servers](https://www.slimframework.com/docs/v3/start/web-servers.html) doc.
+オートロード（`composer.json`）は PSR-4 で `dev_t0r\` を `lib/` と `src/` の **両方** に
+マッピングしています。生成コードと手書きコードが同じ名前空間ツリーに同居し、
+ルーティングはクラス名規約（`XxxApi` → `dev_t0r\trvis_backend\api\XxxApi`）で解決されます。
 
-## Installation via [Composer](https://getcomposer.org/)
+### 実装のレイヤ（`src/trvis_backend/`）
 
-Navigate into your project's root directory and execute the bash command shown below.
-This command downloads the Slim Framework and its third-party dependencies into your project's `vendor/` directory.
-```bash
-$ composer install
+```
+api/      … HTTP ハンドラ。リクエスト検証 → service 呼び出し → レスポンス整形
+service/  … ユースケース／権限判定。トランザクション境界
+repo/     … SQL（PDO）。1 テーブル ≒ 1 リポジトリ
+validator/… 型・値バリデーションルール群
+model/    … 列挙型・日時など手書きモデル補助
+auth/     … MyAuthMiddleware（認証トークン検証）
 ```
 
-## Add configs
+## 認証・認可モデル
 
-[PHP-DI package](https://php-di.org/doc/getting-started.html) helps to decouple configuration from implementation. App loads configuration files in straight order(`$env` can be `prod` or `dev`):
-1. `config/$env/default.inc.php` (contains safe values, can be committed to vcs)
-2. `config/$env/config.inc.php` (user config, excluded from vcs, can contain sensitive values, passwords etc.)
-3. `lib/App/RegisterDependencies.php`
+**「リクエストをゲートする」のではなく「権限でフィルタする」方式**です。
 
-When running via `docker compose`, copy the tracked docker template to the
-(gitignored) user config before bringing the stack up:
-```bash
-$ cp backend/config/prod/config.docker.inc.php backend/config/prod/config.inc.php
-```
-This template points the DB at `webmon-db` and the Firebase Auth Emulator at
-`webmon-firebase:9099` (the in-compose hostnames).
+- `MyAuthMiddleware` は `Authorization: Bearer <token>` が **付いていれば** Firebase で検証する。
+  - 不正なトークン → `400`
+  - 期限切れトークン → `401`
+- トークンが **無ければそのまま通し**、ハンドラには匿名 UID（`Constants::UID_ANONYMOUS`）が渡る。
+- 参照系（`GET`）は匿名でも通るが、返るのは **その利用者に見える範囲だけ**。
+  匿名の権限で見える行がゼロなら `200 []`（＝仕様どおりの正常応答であり、脆弱性ではない）。
+- 作成・更新・削除は匿名を拒否（`401 "Token was not set"`）。
 
-## Start devserver
+権限の最上位単位は **Project** です（旧 WorkGroup 単位の権限を置き換え）。
+詳細は [`../api_defs/`](../api_defs/README.md) の OpenAPI 定義を参照してください。
 
-Run the following command in terminal to start localhost web server, assuming `./php-slim-server/public/` is public-accessible directory with `index.php` file:
-```bash
-$ php -S localhost:8888 -t php-slim-server/public
-```
-> **Warning** This web server was designed to aid application development.
-> It may also be useful for testing purposes or for application demonstrations that are run in controlled environments.
-> It is not intended to be a full-featured web server. It should not be used on a public network.
+## 設定（`config/`）
 
-## Tests
+環境（`APP_ENV` で `dev` / `prod` を切替、未指定なら `prod`）ごとに 2〜3 ファイルの重ね合わせ:
 
-### PHPUnit
+| ファイル                                | VCS        | 役割                                                                 |
+| --------------------------------------- | ---------- | -------------------------------------------------------------------- |
+| `config/$env/default.inc.php`           | 追跡       | 機密を含まない既定値。**常に読み込まれる**                            |
+| `config/$env/config.inc.php`            | gitignore  | 開発者ごとのローカル上書き。**存在すれば**読み込まれる（秘密はここ）  |
+| `config/prod/config.docker.inc.php`     | 追跡       | Docker 用テンプレート。名前では読まれない。コピー元として使う        |
 
-This package uses PHPUnit 8 or 9(depends from your PHP version) for unit testing.
-[Test folder](tests) contains templates which you can fill with real test assertions.
-How to write tests read at [2. Writing Tests for PHPUnit - PHPUnit 8.5 Manual](https://phpunit.readthedocs.io/en/8.5/writing-tests-for-phpunit.html).
+Docker Compose で起動する場合は、テンプレートを `config.inc.php` にコピーします:
 
-#### Run
-
-Command | Target
----- | ----
-`$ composer test` | All tests
-`$ composer test-apis` | Apis tests
-`$ composer test-models` | Models tests
-
-#### Config
-
-Package contains fully functional config `./phpunit.xml.dist` file. Create `./phpunit.xml` in root folder to override it.
-
-Quote from [3. The Command-Line Test Runner — PHPUnit 8.5 Manual](https://phpunit.readthedocs.io/en/8.5/textui.html#command-line-options):
-
-> If phpunit.xml or phpunit.xml.dist (in that order) exist in the current working directory and --configuration is not used, the configuration will be automatically read from that file.
-
-### PHP CodeSniffer
-
-[PHP CodeSniffer Documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki). This tool helps to follow coding style and avoid common PHP coding mistakes.
-
-#### Run
-
-```bash
-$ composer phpcs
+```sh
+cp config/prod/config.docker.inc.php config/prod/config.inc.php
 ```
 
-#### Config
+`config.docker.inc.php` は DB を `webmon-db`、Firebase Auth Emulator を
+`webmon-firebase:9099` に向けた固定値を持ちます（同一 compose ネットワーク前提）。
+`config.inc.php` は Git 管理外なので、機密値はここに書きます。
 
-Package contains fully functional config `./phpcs.xml.dist` file. It checks source code against PSR-1 and PSR-2 coding standards.
-Create `./phpcs.xml` in root folder to override it. More info at [Using a Default Configuration File](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file)
+## 起動方法
 
-### PHPLint
+### ホスト PHP の組み込みサーバ（開発時）
 
-[PHPLint Documentation](https://github.com/overtrue/phplint). Checks PHP syntax only.
+リポジトリルートの補助スクリプトを使います:
 
-#### Run
-
-```bash
-$ composer phplint
+```sh
+./_php.sh        # backend/ で php -S localhost:8888 -t public
 ```
 
-## Show errors
+→ `http://localhost:8888/api/v1/`
 
-Switch your app environment to development in `public/.htaccess` file:
-```ini
-## .htaccess
-<IfModule mod_env.c>
-    SetEnv APP_ENV 'development'
-</IfModule>
+### Docker Compose
+
+リポジトリルートの [`README.md`](../README.md) のクイックスタート参照。
+`php` コンテナは proxy 経由のほか `http://localhost:8080/api/v1/` で直接叩けます。
+
+## テスト
+
+PHPUnit 11（`vendor/` に同梱）。`backend/` 直下で実行します。
+
+```sh
+composer test          # 全テスト
+composer test-apis     # phpunit --testsuite Apis（tests/Api）
+composer test-models   # phpunit --testsuite Models（tests/Model）
+composer phpcs         # コーディング規約チェック
+composer phplint       # 構文チェック（vendor を除外）
 ```
 
-## Mock Server
-Since this feature should be used for development only, change environment to `development` and send additional HTTP header `X-dev_t0r-Mock: ping` with any request to get mocked response.
-CURL example:
-```console
-curl --request GET \
-    --url 'http://localhost:8888/v2/pet/findByStatus?status=available' \
-    --header 'accept: application/json' \
-    --header 'X-dev_t0r-Mock: ping'
-[{"id":-8738629417578509312,"category":{"id":-4162503862215270400,"name":"Lorem ipsum dol"},"name":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem i","photoUrls":["Lor"],"tags":[{"id":-3506202845849391104,"name":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectet"}],"status":"pending"}]
+`tests/Integration/` および一部の API テストは実 DB に接続します。
+DB が無い環境では skip ガードされます。CI（`.github/workflows/backend-tests.yml`）は
+PHP 8.2 + MySQL 8.0 で実 DB 統合テストまで含めて実行します。
+
+## コード生成との関係（重要）
+
+`lib/` や `public/index.php` は OpenAPI Generator の出力です。
+**手で編集してはいけません**（次回生成で上書きされます）。
+
+API を変えるときは `../api_defs/` の OpenAPI 定義を編集し、再生成します:
+
+```sh
+cd ../api_defs
+./bundle.sh        # 仕様をバンドル（openapi.bundle.yml を生成）
+./gen_php.sh       # backend/ を再生成
 ```
 
-Used packages:
-* [Openapi Data Mocker](https://github.com/ybelenko/openapi-data-mocker) - first implementation of OAS3 fake data generator.
-* [Openapi Data Mocker Server Middleware](https://github.com/ybelenko/openapi-data-mocker-server-middleware) - PSR-15 HTTP server middleware.
-* [Openapi Data Mocker Interfaces](https://github.com/ybelenko/openapi-data-mocker-interfaces) - package with mocking interfaces.
-
-## Logging
-
-Build contains pre-configured [`monolog/monolog`](https://github.com/Seldaek/monolog) package. Make sure that `logs` folder is writable.
-Add required log handlers/processors/formatters in `lib/App/RegisterDependencies.php`.
-
-## API Endpoints
-
-All URIs are relative to *http://localhost:8080/api/v1*
-
-> Important! Do not modify abstract API controllers directly! Instead extend them by implementation classes like:
-
-```php
-// src/Api/PetApi.php
-
-namespace dev_t0r\trvis_backend\api;
-
-use dev_t0r\trvis_backend\api\AbstractPetApi;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\ResponseInterface;
-
-class PetApi extends AbstractPetApi
-{
-    public function addPet(
-        ServerRequestInterface $request,
-        ResponseInterface $response
-    ): ResponseInterface {
-        // your implementation of addPet method here
-    }
-}
-```
-
-When you need to inject dependencies into API controller check [PHP-DI - Controllers as services](https://github.com/PHP-DI/Slim-Bridge#controllers-as-services) guide.
-
-Place all your implementation classes in `./src` folder accordingly.
-For instance, when abstract class located at `./lib/Api/AbstractPetApi.php` you need to create implementation class at `./src/Api/PetApi.php`.
-
-Class | Method | HTTP request | Description
------------- | ------------- | ------------- | -------------
-*AbstractApiInfoApi* | **getApiInfo** | **GET** / | APIの情報を取得する
-*AbstractAuthApi* | **issueToken** | **POST** /auths | (未実装) 認証トークンを発行
-*AbstractColorApi* | **createColor** | **POST** /work_groups/{workGroupId}/colors | 作成する
-*AbstractColorApi* | **deleteColor** | **DELETE** /colors/{colorId} | 削除する
-*AbstractColorApi* | **getColor** | **GET** /colors/{colorId} | 1件取得する
-*AbstractColorApi* | **getColorList** | **GET** /work_groups/{workGroupId}/colors | 複数件取得する
-*AbstractColorApi* | **updateColor** | **PUT** /colors/{colorId} | 更新する
-*AbstractDumpApi* | **dumpTimetable** | **GET** /dump/{workGroupId} | まとめて出力する
-*AbstractInviteKeyApi* | **getMyInviteKeyList** | **GET** /invite_keys | 一覧を取得する
-*AbstractInviteKeyApi* | **createInviteKey** | **POST** /work_groups/{workGroupId}/invite_keys | 作成する
-*AbstractInviteKeyApi* | **deleteInviteKey** | **DELETE** /invite_keys/{inviteKeyId} | 無効化する
-*AbstractInviteKeyApi* | **getInviteKey** | **GET** /invite_keys/{inviteKeyId} | 1件取得する
-*AbstractInviteKeyApi* | **getInviteKeyList** | **GET** /work_groups/{workGroupId}/invite_keys | 一覧を取得する
-*AbstractInviteKeyApi* | **updateInviteKey** | **PUT** /invite_keys/{inviteKeyId} | (未実装) 更新する
-*AbstractInviteKeyApi* | **useInviteKey** | **POST** /invite_keys/{inviteKeyId} | 使用する
-*AbstractLineApi* | **createLine** | **POST** /projects/{projectId}/lines | 作成する
-*AbstractLineApi* | **deleteLine** | **DELETE** /lines/{lineId} | 削除する
-*AbstractLineApi* | **getLine** | **GET** /lines/{lineId} | 1件取得する
-*AbstractLineApi* | **getLineList** | **GET** /projects/{projectId}/lines | 複数件取得する
-*AbstractLineApi* | **updateLine** | **PUT** /lines/{lineId} | 更新する
-*AbstractProjectApi* | **createProject** | **POST** /projects | 作成する
-*AbstractProjectApi* | **getProjectList** | **GET** /projects | 複数件取得する
-*AbstractProjectApi* | **deleteProject** | **DELETE** /projects/{projectId} | 削除する
-*AbstractProjectApi* | **getProject** | **GET** /projects/{projectId} | 1件取得する
-*AbstractProjectApi* | **getProjectPrivilege** | **GET** /projects/{projectId}/privileges | 権限情報を取得する
-*AbstractProjectApi* | **updateProject** | **PUT** /projects/{projectId} | 更新する
-*AbstractProjectApi* | **updateProjectPrivilege** | **PUT** /projects/{projectId}/privileges | 権限を更新する
-*AbstractProjectStationApi* | **createProjectStation** | **POST** /projects/{projectId}/project_stations | 作成する
-*AbstractProjectStationApi* | **deleteProjectStation** | **DELETE** /project_stations/{projectStationId} | 削除する
-*AbstractProjectStationApi* | **getProjectStation** | **GET** /project_stations/{projectStationId} | 1件取得する
-*AbstractProjectStationApi* | **getProjectStationList** | **GET** /projects/{projectId}/project_stations | 複数件取得する
-*AbstractProjectStationApi* | **updateProjectStation** | **PUT** /project_stations/{projectStationId} | 更新する
-*AbstractStationApi* | **createStation** | **POST** /work_groups/{workGroupId}/stations | 作成する
-*AbstractStationApi* | **deleteStation** | **DELETE** /stations/{stationId} | 削除する
-*AbstractStationApi* | **getStation** | **GET** /stations/{stationId} | 1件取得する
-*AbstractStationApi* | **getStationList** | **GET** /work_groups/{workGroupId}/stations | 複数件取得する
-*AbstractStationApi* | **updateStation** | **PUT** /stations/{stationId} | 更新する
-*AbstractStationOnLineApi* | **createStationOnLine** | **POST** /lines/{lineId}/stations_on_line | 作成する
-*AbstractStationOnLineApi* | **deleteStationOnLine** | **DELETE** /stations_on_line/{stationOnLineId} | 削除する
-*AbstractStationOnLineApi* | **getStationOnLine** | **GET** /stations_on_line/{stationOnLineId} | 1件取得する
-*AbstractStationOnLineApi* | **getStationOnLineList** | **GET** /lines/{lineId}/stations_on_line | 複数件取得する
-*AbstractStationOnLineApi* | **updateStationOnLine** | **PUT** /stations_on_line/{stationOnLineId} | 更新する
-*AbstractStationTrackApi* | **createStationTrack** | **POST** /stations/{stationId}/tracks | 作成する
-*AbstractStationTrackApi* | **deleteStationTrack** | **DELETE** /tracks/{stationTrackId} | 削除する
-*AbstractStationTrackApi* | **getStationTrack** | **GET** /tracks/{stationTrackId} | 1件取得する
-*AbstractStationTrackApi* | **getStationTrackList** | **GET** /stations/{stationId}/tracks | 複数件取得する
-*AbstractStationTrackApi* | **updateStationTrack** | **PUT** /tracks/{stationTrackId} | 更新する
-*AbstractStopPatternApi* | **createStopPattern** | **POST** /projects/{projectId}/stop_patterns | 作成する
-*AbstractStopPatternApi* | **deleteStopPattern** | **DELETE** /stop_patterns/{stopPatternId} | 削除する
-*AbstractStopPatternApi* | **getStopPattern** | **GET** /stop_patterns/{stopPatternId} | 1件取得する
-*AbstractStopPatternApi* | **getStopPatternList** | **GET** /projects/{projectId}/stop_patterns | 複数件取得する
-*AbstractStopPatternApi* | **updateStopPattern** | **PUT** /stop_patterns/{stopPatternId} | 更新する
-*AbstractStopPatternRowApi* | **createStopPatternRow** | **POST** /stop_patterns/{stopPatternId}/rows | 作成する
-*AbstractStopPatternRowApi* | **deleteStopPatternRow** | **DELETE** /stop_pattern_rows/{stopPatternRowId} | 削除する
-*AbstractStopPatternRowApi* | **getStopPatternRow** | **GET** /stop_pattern_rows/{stopPatternRowId} | 1件取得する
-*AbstractStopPatternRowApi* | **getStopPatternRowList** | **GET** /stop_patterns/{stopPatternId}/rows | 複数件取得する
-*AbstractStopPatternRowApi* | **updateStopPatternRow** | **PUT** /stop_pattern_rows/{stopPatternRowId} | 更新する
-*AbstractTimetableRowApi* | **createTimetableRow** | **POST** /trains/{trainId}/timetable_rows | 作成する
-*AbstractTimetableRowApi* | **deleteTimetableRow** | **DELETE** /timetable_rows/{timetableRowId} | 削除する
-*AbstractTimetableRowApi* | **getTimetableRow** | **GET** /timetable_rows/{timetableRowId} | 1件取得する
-*AbstractTimetableRowApi* | **getTimetableRowList** | **GET** /trains/{trainId}/timetable_rows | 複数件取得する
-*AbstractTimetableRowApi* | **updateTimetableRow** | **PUT** /timetable_rows/{timetableRowId} | 更新する
-*AbstractTrainApi* | **createTrain** | **POST** /works/{workId}/trains | 作成する
-*AbstractTrainApi* | **deleteTrain** | **DELETE** /trains/{trainId} | 削除する
-*AbstractTrainApi* | **getTrain** | **GET** /trains/{trainId} | 1件取得する
-*AbstractTrainApi* | **getTrainList** | **GET** /works/{workId}/trains | 複数件取得する
-*AbstractTrainApi* | **updateTrain** | **PUT** /trains/{trainId} | 更新する
-*AbstractWorkApi* | **createWork** | **POST** /work_groups/{workGroupId}/works | 作成する
-*AbstractWorkApi* | **deleteWork** | **DELETE** /works/{workId} | 削除する
-*AbstractWorkApi* | **getWork** | **GET** /works/{workId} | 1件取得する
-*AbstractWorkApi* | **getWorkList** | **GET** /work_groups/{workGroupId}/works | 複数件取得する
-*AbstractWorkApi* | **updateWork** | **PUT** /works/{workId} | 更新する
-*AbstractWorkGroupApi* | **createWorkGroup** | **POST** /work_groups | 作成する
-*AbstractWorkGroupApi* | **getWorkGroupList** | **GET** /work_groups | 複数件取得する
-*AbstractWorkGroupApi* | **createWorkGroupInProject** | **POST** /projects/{projectId}/work_groups | 作成する
-*AbstractWorkGroupApi* | **deleteWorkGroup** | **DELETE** /work_groups/{workGroupId} | 削除する
-*AbstractWorkGroupApi* | **getPrivilege** | **GET** /work_groups/{workGroupId}/privileges | 権限情報を取得する
-*AbstractWorkGroupApi* | **getWorkGroup** | **GET** /work_groups/{workGroupId} | 1件取得する
-*AbstractWorkGroupApi* | **getWorkGroupListByProject** | **GET** /projects/{projectId}/work_groups | 複数件取得する
-*AbstractWorkGroupApi* | **updatePrivilege** | **PUT** /work_groups/{workGroupId}/privileges | 権限を更新する
-*AbstractWorkGroupApi* | **updateWorkGroup** | **PUT** /work_groups/{workGroupId} | 更新する
-
-
-## Models
-
-* dev_t0r\trvis_backend\model\ApiInfo
-* dev_t0r\trvis_backend\model\Color
-* dev_t0r\trvis_backend\model\Color8bit
-* dev_t0r\trvis_backend\model\ColorReal
-* dev_t0r\trvis_backend\model\InviteKey
-* dev_t0r\trvis_backend\model\Line
-* dev_t0r\trvis_backend\model\Project
-* dev_t0r\trvis_backend\model\ProjectStation
-* dev_t0r\trvis_backend\model\ProjectStationLocationLonlat
-* dev_t0r\trvis_backend\model\ProjectsPrivilege
-* dev_t0r\trvis_backend\model\Schema
-* dev_t0r\trvis_backend\model\Station
-* dev_t0r\trvis_backend\model\StationLocationLonlat
-* dev_t0r\trvis_backend\model\StationOnLine
-* dev_t0r\trvis_backend\model\StationOnLineLocationLonlat
-* dev_t0r\trvis_backend\model\StationTrack
-* dev_t0r\trvis_backend\model\StopPattern
-* dev_t0r\trvis_backend\model\StopPatternRow
-* dev_t0r\trvis_backend\model\TRViSJsonTimetableRow
-* dev_t0r\trvis_backend\model\TRViSJsonTrain
-* dev_t0r\trvis_backend\model\TRViSJsonWork
-* dev_t0r\trvis_backend\model\TRViSJsonWorkGroup
-* dev_t0r\trvis_backend\model\TimetableRow
-* dev_t0r\trvis_backend\model\TokenRequest
-* dev_t0r\trvis_backend\model\TokenResponse
-* dev_t0r\trvis_backend\model\Train
-* dev_t0r\trvis_backend\model\Work
-* dev_t0r\trvis_backend\model\WorkGroup
-* dev_t0r\trvis_backend\model\WorkGroupsPrivilege
-
-
-## Authentication
-
-### Advanced middleware configuration
-Ref to used Slim Token Middleware [dyorg/slim-token-authentication](https://github.com/dyorg/slim-token-authentication/tree/1.x#readme)
+生成器が**上書きしてはいけない**ファイルは `.openapi-generator-ignore` に列挙しています
+（`composer.json`、`config/`、`public/index.php`、DI/ミドルウェア登録、本 `README.md` など）。
+手書きで残したいファイルを増やすときは、必ずこのファイルにも追記してください。

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,94 @@
+# TRViS Timetable Server — Frontend
+
+[TRViS](https://github.com/TetsuOtter/TRViS) 用の時刻表データを編集する Web フロントエンドです。
+React 18 + TypeScript + [Vite](https://vitejs.dev/) で実装し、パッケージ管理は Yarn 4（Berry）です。
+
+バックエンド API は [`../backend/`](../backend/README.md)、API 仕様は
+[`../api_defs/`](../api_defs/README.md) を参照してください。
+
+## 技術スタック
+
+| 領域           | 採用                                                                       |
+| -------------- | -------------------------------------------------------------------------- |
+| UI             | React 18 + TypeScript（独自デザインバンドル）                              |
+| ビルド         | Vite 5（`@vitejs/plugin-react-swc`、`vite-plugin-svgr`）                   |
+| データ取得     | [TanStack Query](https://tanstack.com/query)（正規化エンティティ）         |
+| API クライアント | `trvis-api`（OpenAPI から生成。`packages/trvis-api` をローカル参照）      |
+| 認証           | Firebase Authentication（開発時は Auth Emulator）                          |
+| 国際化         | i18next / react-i18next                                                     |
+| パッケージ管理 | Yarn 4（`packageManager: yarn@4.13.0`、`nodeLinker: node-modules`）        |
+
+> `package.json` には MUI / Redux / react-router の依存が残っていますが、
+> 現在の `src/` はこれらを使っていません（独自デザインバンドルへ移行済み）。
+> 実装の実態はこの README とソースが正で、`package.json` の依存一覧ではありません。
+
+## ディレクトリ構成（`src/`）
+
+```text
+main.tsx       … エントリ。AppProviders → App をマウント
+app/           … App / AppProviders / AuthContext / AuthGate / SettingsContext
+api/           … client・adapters・instances・queryClient・queryKeys と hooks/
+components/    … 画面コンポーネント（ProjectList, TimetableGrid 等）
+data/          … サンプルデータ
+firebase/      … Firebase 初期化
+i18n/          … 翻訳リソース
+lib/ utils/ types/ styles/ assets/
+```
+
+`packages/trvis-api/` は OpenAPI Generator（`typescript-fetch`）の出力です。
+`package.json` で `trvis-api: link:./packages/trvis-api` として参照しているため、
+**フロントをビルドする前に必ずこのパッケージをビルド**しておく必要があります（後述）。
+
+## 環境変数
+
+`.env.sample` をコピーして `.env` を作り、値を埋めます。
+
+```sh
+cp .env.sample .env
+```
+
+| 変数                              | 用途                                                        |
+| --------------------------------- | ----------------------------------------------------------- |
+| `VITE_FIREBASE_API_KEY`           | Firebase Web API キー                                       |
+| `VITE_FIREBASE_MESSAGE_SENDER_ID` | Firebase Messaging Sender ID                                |
+| `VITE_FIREBASE_APP_ID`            | Firebase App ID                                             |
+| `VITE_API_BASE_URL`               | API ベース URL（既定 `/api/v1` ＝ nginx 経由の同一オリジン）|
+
+`.env` は Git 管理外です。`Dockerfile` はビルド時に `./.env` をコンテナへコピーするため、
+**Docker ビルド前にも `.env` を用意**しておく必要があります。
+
+## 開発・ビルド
+
+```sh
+corepack enable                         # Yarn 4 を有効化
+yarn install --immutable                # 依存をインストール
+
+# trvis-api（生成クライアント）を先にビルド
+( cd packages/trvis-api && npm install && npm run build )
+
+yarn dev        # 開発サーバ（Vite）
+yarn build      # tsc && vite build（本番ビルド → dist/）
+yarn lint       # ESLint（--max-warnings 0）
+yarn i18n       # i18next-parser で翻訳キー抽出
+yarn preview    # ビルド成果物のプレビュー
+```
+
+`vite.config.ts` は `build.commonjsOptions.include` に `packages/trvis-api` を含めて
+リンクされた生成パッケージを取り込みます。また本番ビルドでは `console` / `debugger` を除去します。
+この設定は意図的なので変更しないでください。
+
+## Docker
+
+`Dockerfile` は 2 ステージ構成です。
+
+1. `node:24.15.0-alpine`: `corepack enable && yarn install --frozen-lockfile` → `yarn build`
+2. `httpd:2.4.58-alpine`: `public/` と `dist/` を Apache httpd で配信
+
+Docker Compose で起動すると、proxy（nginx）経由で `http://localhost/` から配信されます。
+詳細はリポジトリルートの [`README.md`](../README.md) を参照してください。
+
+## CI
+
+`.github/workflows/frontend-tests.yml` がマージゲートです。
+`trvis-api` の生成クライアントをビルド → `tsc`（型検査）→ `vite build` を実行します。
+テストランナーは無く、**型検査が正しさの基準**です。型エラーはマージをブロックします。

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -1,174 +1,75 @@
-# データベース関係
+# TRViS Timetable Server — Database（MySQL）
 
-## 持たせるデータ
+[TRViS](https://github.com/TetsuOtter/TRViS) 時刻表データを格納する MySQL 8.0 です。
+Docker Compose では `mysql`（コンテナ名 `webmon-db`）として起動し、
+バックエンド（`php`）からのみ内部ネットワーク経由でアクセスされます。
 
-### v1_0
+## ディレクトリ構成
 
-- api_keys
-  - (common)
-    - api_keys_id
-    - created_at
-    - owner
-    - description
-  - api_key
-  - expires_at
-- work_groups_privileges
-  - uid
-  - work_groups_id
-  - invite_keys_id
-  - created_at
-  - updated_at
-  - deleted_at
-  - privilege_type
-    - none = 0
-    - read = 1
-    - write = 2
-    - admin = 3
-- invite_keys
-  - invite_keys_id
-  - work_groups_id
-  - created_at
-  - owner
-  - updated_at
-  - deleted_at
-  - description
-  - valid_from
-  - expires_at
-  - use_limit
-  - disabled_at
-  - privilege_type
-    - none = 0
-    - read = 1
-    - write = 2
-    - admin = 3
+| パス             | 内容                                                                       |
+| ---------------- | -------------------------------------------------------------------------- |
+| `init_sql/`      | 初回起動時に実行される初期化 SQL                                           |
+| `conf.d/my.cnf`  | MySQL 設定（`utf8mb4`、スロークエリログ等）                                |
+| `logs/`          | エラーログ・スロークエリログのバインド先（ログ本体は Git 管理外）          |
+| `.env.sample`    | 認証情報のテンプレート                                                      |
+| `.env`           | 実際の認証情報（`.env.sample` からコピー。**Git 管理外**）                 |
 
-- work_groups
-  - (common)
-    - work_groups_id
-    - created_at
-    - owner
-    - updated_at
-    - deleted_at
-    - description
-  - name
-- works
-  - (common)
-    - works_id
-    - work_groups_id
-    - description
-    - created_at
-    - owner
-    - updated_at
-    - deleted_at
-  - name
-  - affect_date
-  - affix_content_type
-  - affix_file_name
-  - remarks
-  - has_e_train_timetable
-  - e_train_timetable_content_type
-  - e_train_timetable_file_name
-- trains
-  - (common)
-    - trains_id
-    - works_id
-    - description
-    - created_at
-    - owner
-    - updated_at
-    - deleted_at
-  - train_number
-  - max_speed
-  - speed_type
-  - nominal_tractive_capacity
-  - car_count
-  - destination
-  - begin_remarks
-  - after_remarks
-  - remarks
-  - before_departure
-  - after_arrive
-  - train_info
-  - direction
-  - day_count
-  - is_ride_on_moving
-- stations
-  - (common)
-    - stations_id
-    - work_groups_id
-    - description
-    - created_at
-    - owner
-    - updated_at
-    - deleted_at
-  - name
-  - location_km
-  - location_lonlat
-  - on_station_detect_radius_m
-  - record_type
-- station_tracks
-  - (common)
-    - station_tracks_id
-    - stations_id
-    - description
-    - created_at
-    - owner
-    - updated_at
-    - deleted_at
-  - name
-  - run_in_limit
-  - run_out_limit
-- timetable_rows
-  - (common)
-    - timetable_rows_id
-    - trains_id
-    - stations_id
-    - station_tracks_id
-    - colors_id_marker
-    - description
-    - created_at
-    - owner
-    - updated_at
-    - deleted_at
-  - drive_time_mm
-  - drive_time_ss
-  - is_operation_only_stop
-  - is_pass
-  - has_bracket
-  - is_last_stop
-  - arrive_hh
-  - arrive_mm
-  - arrive_ss
-  - departure_hh
-  - departure_mm
-  - departure_ss
-  - run_in_limit
-  - run_out_limit
-  - remarks
-  - arrive_str
-  - departure_str
-  - marker_text
-  - work_type
-- colors
-  - (common)
-    - colors_id
-    - work_groups_id
-    - description
-    - created_at
-    - owner
-    - updated_at
-    - deleted_at
-  - name
-  - red_8bit
-  - green_8bit
-  - blue_8bit
-  - red_real
-  - green_real
-  - blue_real
+## スキーマ（正は SQL ファイル）
 
-trainsの `before_departure_on_station_track_col` 等は、deprecatedとするため含めない。
+**スキーマの source-of-truth は [`init_sql/0_create_db.sql`](init_sql/0_create_db.sql)** です。
+このファイルに定義された 17 テーブルが初回起動時に作成されます:
 
-削除操作は論理削除とし、操作量の都合で以下のテーブル以外への `deleted_at` 設定はバッチ処理にする。
-- work_groups_privileges
-- invite_keys
-- work_groups
+```text
+projects                  … 権限の最上位単位（旧 WorkGroup 権限を置き換える privilege root）
+work_groups               … projects 配下（projects_id は NOT NULL）
+project_lines             … 路線（後述の予約語回避）
+project_stations          … Project 共通の駅
+stations_on_line          … 路線上の駅
+stop_patterns             … 停車パターン
+stop_pattern_rows         … 停車パターンの行
+works / trains / timetable_rows / stations / station_tracks / colors
+api_keys / invite_keys
+work_groups_privileges / projects_privileges
+```
+
+FK のルート連鎖は `projects` を起点に
+`work_groups` / `project_lines` / `project_stations` / `stop_patterns` へ伸びます。
+
+### 設計上の注意
+
+- **`lines` は MySQL の予約語**のため、DB 上のテーブル名・カラム名は
+  `project_lines` / `project_lines_id` を使います。OpenAPI 定義では `Line` / `lines_id`
+  のままで、バックエンドの repo 層でエイリアスして吸収しています。
+- UUID は `BINARY(16)` で格納します。
+- 削除は **論理削除**（`deleted_at` を設定）が基本です。
+
+旧版で手書きしていたデータモデル仕様（旧 `work_groups` 権限ベース）は廃止しました。
+現行スキーマは必ず SQL ファイルを参照してください。
+API としての見え方は [`../api_defs/README.md`](../api_defs/README.md) を参照。
+
+## 認証情報
+
+```sh
+cp .env.sample .env
+```
+
+| 変数                  | 既定値 | 用途                       |
+| --------------------- | ------ | -------------------------- |
+| `MYSQL_USER`          | `test` | アプリ用ユーザ             |
+| `MYSQL_PASSWORD`      | `test` | 同パスワード               |
+| `MYSQL_DATABASE`      | `test` | データベース名             |
+| `MYSQL_ROOT_PASSWORD` | `test` | root パスワード            |
+
+バックエンドの接続先（Docker 構成）は
+`backend/config/prod/config.docker.inc.php` の DSN（`host=webmon-db;dbname=test`）と
+一致させます。詳細は [`../backend/README.md`](../backend/README.md) を参照してください。
+
+## 接続（開発時）
+
+リポジトリルートの補助スクリプトでコンテナ内 `mysql` クライアントへ接続できます:
+
+```sh
+./_mysql.sh
+```
+
+DB 管理 UI が必要なときは phpMyAdmin（`http://localhost:81/`）も利用できます。


### PR DESCRIPTION
## 概要

手書き管理の README をすべて現状のコードベースに合わせて書き直しました。

## 変更内容

| ファイル | 変更 | 内容 |
| --- | --- | --- |
| `README.md`（最上位） | 書き直し | 構成図・サービス/ポート表・Docker クイックスタート・補助スクリプト・API/CI |
| `backend/README.md` | 全面書き直し | 旧 OpenAPI Petstore ボイラープレートを破棄。Slim 4 構成・api/service/repo レイヤ・権限フィルタ型認証・config 三層・テスト・コード生成との関係 |
| `backend/.openapi-generator-ignore` | 1 行追加 | `README.md` を追加。次回 `gen_php.sh` での README 上書きを防止（backend 書き直しと同一コミット） |
| `frontend/README.md` | 新規作成 | React18/Vite/Yarn4/TanStack Query/Firebase/i18next。`trvis-api` 事前ビルドの必要性・`.env`・Docker・CI が型検査ゲートである点 |
| `api_defs/README.md` | 書き直し | 既存の設計意図を温存しつつ source-of-truth・bundle/gen ワークフロー・生成器 7.2.0 ピン |
| `mysql/README.md` | 書き直し | 旧 v1_0 手書き仕様を破棄し `init_sql/0_create_db.sql` を正に。17 テーブル・FK ルート連鎖・`project_lines` 予約語回避 |

## 補足

- 内容は `docker-compose.yaml` / 各 `Dockerfile` / `composer.json` / `vite.config.ts` / `config/*/default.inc.php` / `init_sql/0_create_db.sql` 等を直接確認して反映。
- `frontend/packages/trvis-api/README.md` は OpenAPI Generator 管理下のため対象外。
- ドキュメントのみの変更でコード・挙動への影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)