### PR TITLE
fix(backend): docker build で composer 依存を同梱し vendor 欠如を解消

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,7 +1,12 @@
 # ref: https://github.com/github/gitignore/blob/master/Composer.gitignore
 
 composer.phar
-/vendor/
+# vendor/ の中身は無視するが、ディレクトリ自体は残す。
+# docker-compose.yaml で ./backend を read_only bind した上に vendor/ へ
+# 名前付きボリュームを被せている。read_only な親の中にマウントポイントは
+# 作れないため、空の vendor/ を host 側に常設するアンカーが必要。
+/vendor/*
+!/vendor/.gitkeep
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,8 +5,35 @@ RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-av
 
 RUN a2enmod rewrite
 
-RUN docker-php-ext-install pdo_mysql
+# 依存パッケージのビルド/実行に必要なシステムライブラリと PHP 拡張。
+# 必要拡張の正準ソースは .github/workflows/backend-tests.yml の
+#   extensions: mbstring, intl, pdo_mysql, bcmath
+# （pdo_mysql は従来からインストール済み。CI とランタイムでパリティを取る）
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    git \
+    unzip \
+    libonig-dev \
+    libicu-dev \
+  && docker-php-ext-install pdo_mysql mbstring intl bcmath \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Composer 本体は公式イメージからバイナリだけ取り込む
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 WORKDIR /var/www/html
+
+# 依存解決はソース全体ではなく lock ファイルだけで行い、レイヤキャッシュを効かせる。
+# アプリ本体 (lib/ src/) は compose の bind mount で供給されるため、ここでは
+# 非最適化の PSR-4 オートローダで十分（実行時にマウント済みソースを解決する）。
+# --no-dev: この php コンテナは API 配信専用。テスト系ツールは CI / ホストで実行。
+COPY composer.json composer.lock ./
+RUN composer install \
+  --no-interaction \
+  --no-progress \
+  --prefer-dist \
+  --no-dev \
+  --no-scripts
 
 EXPOSE 80

--- a/backend/vendor/.gitkeep
+++ b/backend/vendor/.gitkeep
@@ -1,0 +1,7 @@
+# このディレクトリは意図的に空のまま追跡しています。
+# docker-compose.yaml の php サービスは ./backend を read_only で bind し、
+# その内側の vendor/ に名前付きボリューム (webmon-php-vendor) を被せます。
+# read_only な親の中には Docker がマウントポイントを作れないため、
+# host 側に空の backend/vendor/ を常設してアンカーにする必要があります。
+# 実際の依存は backend/Dockerfile の `composer install` でイメージ内に入り、
+# 上記ボリューム経由でコンテナに供給されます（host のこのディレクトリは空のまま）。

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,6 +49,13 @@ services:
         read_only: true
         source: ./backend
         target: /var/www/html
+      # ./backend は read_only bind。イメージビルド時に composer install した
+      # vendor/ を上書き（シャドウ）しないよう、ここだけ名前付きボリュームを被せる。
+      # 注意: composer.json/lock 変更後にイメージを作り直しても、このボリュームが
+      # 残っていると旧 vendor が居座る。`docker compose down -v` で作り直すこと。
+      - type: volume
+        source: webmon-php-vendor
+        target: /var/www/html/vendor
       - type: bind
         source: ./backend-logs
         target: /var/log/apache2
@@ -117,6 +124,7 @@ services:
       - mysql
 volumes:
   webmon-db:
+  webmon-php-vendor:
 networks:
   proxy-front:
   proxy-back:


### PR DESCRIPTION
## 問題

`http://localhost/api/v1/projects` が以下で fatal になっていた:

```
require_once(/var/www/html/public/../vendor/autoload.php): Failed to open stream: No such file or directory
```

原因: `backend/Dockerfile` が `composer install` を行わず、`backend/vendor/` は gitignore で host にも存在せず、さらに `docker-compose.yaml` で `./backend` を **read_only** bind しているため `vendor/` がどこにも無い。README のクイックスタート `docker compose up -d --build` がそのままでは成立しない状態だった。

## 変更

- **backend/Dockerfile**: 公式 `composer:2` イメージから composer 本体を取り込み、依存に必要な PHP 拡張 (`mbstring` / `intl` / `pdo_mysql` / `bcmath` — 正準ソースは `.github/workflows/backend-tests.yml` の `extensions`) を追加。`composer.lock` からビルド時に `composer install --no-dev`（この php コンテナは API 配信専用、テスト系ツールは CI / ホスト）。
- **docker-compose.yaml**: `./backend` の read_only bind がイメージ内 `vendor/` を上書き（シャドウ）しないよう、`/var/www/html/vendor` にだけ名前付きボリューム `webmon-php-vendor` を被せる。
- **backend/.gitignore / backend/vendor/.gitkeep**: read_only な親の内側に Docker はマウントポイントを作れないため、空の `backend/vendor/` を host 側アンカーとして追跡（`.gitignore` を `/vendor/*` + `!/vendor/.gitkeep` に変更）。

## 確認

`docker compose build php` → `up --force-recreate php` 後、`vendor/autoload.php` の fatal は解消（autoload は通る）。

> **注意（運用）**: `composer.json` / `composer.lock` 変更後にイメージを作り直しても、`webmon-php-vendor` ボリュームが残っていると旧 `vendor` が居座る。`docker compose down -v`（または該当ボリューム削除）で作り直すこと。compose 内にもコメントで明記済み。

## スコープ外の別件（本 PR では未対応）

vendor 解消後、`/api/v1/projects` は別要因で 500 になることを確認:
`RegisterDependencies.php:141` が Auth Emulator 利用時も無条件で `Firebase\Factory->withServiceAccount()` を呼び、存在しない `config/prod/firebase-service-account.json` で例外。これは本 PR の vendor 問題とは独立した、ローカル/エミュレータ向け Firebase セットアップの未整備（別途対応が必要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)