### PR TITLE
feat: project export/import API + full E2E suite (71 tests) + all-button fixes

### DIFF
--- a/UNIMPLEMENTED.md
+++ b/UNIMPLEMENTED.md
@@ -165,10 +165,11 @@ App.tsx は API（TanStack Query）から描画する一方、`data = useState(c
 App.tsx:1490-1491 が WorkBrowser に `stationsOnLine={data.stationsOnLine}` /
 `lines={data.lines}`（サンプル）を渡す。結果、列車のパターン適用ダイアログの路線
 ドロップダウンに実プロジェクトの路線でなくサンプル（l1/l2）が出る。
-- **[修正済(一部)]** App.tsx:1490-1491 を `modelLines` / `modelStationsOnLine`
-  （API 由来）に変更。路線ドロップダウンの実データ化を達成、tsc グリーン。
-  ※ 残課題: `modelStationsOnLine` は選択中 line 単位の取得のため、別 line の
-  パターンの経由駅解決には不足。プロジェクト全体の stationsOnLine 供給は follow-up。
+- **[修正済]** App.tsx の `stationsOnLine` を全ライン分に拡張。
+  `useAllStationsOnLine(allLineIds)` を追加し、WorkBrowser (ApplyPatternDialog) と
+  StopPatternWizard に `modelAllStationsOnLine` を渡す。各ラインのデータは同一
+  queryKey でキャッシュ共有されるため重複リクエストなし。LineManager は引き続き
+  `modelStationsOnLine`（選択中ライン）を使用（CRUD スコープが currentLine 単位）。
 
 ---
 

--- a/UNIMPLEMENTED.md
+++ b/UNIMPLEMENTED.md
@@ -1,0 +1,225 @@
+# 未実装・誤配線・サーバ起因の機能一覧（E2E棚卸し）
+
+`feature/all-button-e2e` で Playwright E2E を整備し、各画面のボタン／ボタン的な
+クリック対象を「効果まで」検証した結果のリスト。分類:
+
+- **UNIMPLEMENTED** … ハンドラ無し／no-op。何も起きない。
+- **WRONG-SOURCE** … 動くが対象データが誤り（API ではなくメモリ上のサンプル
+  `data` を読み書きする等）。見た目は反応するが実データに反映されない。
+- **BACKEND-500** … フロントは正しく API を叩くがサーバが 500 を返す（実バグ）。
+- **ENV/CONFIG** … docker/emulator 開発環境の設定不備でミューテーションが全滅して
+  いた基盤問題（E2E の前提として要対応）。
+
+各項目の末尾に **[状態]** を付す: `修正済` / `要対応` / `要設計判断`。
+
+E2E ハーネスと実行手順は [`frontend/e2e/README.md`](frontend/e2e/README.md) 参照
+（`docker compose up -d php mysql firebase` → `cd frontend && yarn playwright test`）。
+
+## 実装・検証サマリ（このブランチで対応済み）
+
+| 項目 | 種別 | 状態 | 検証 |
+|---|---|---|---|
+| 失効チェックが emulator で 401（§0-1） | ENV | **修正済(追跡)** `MyAuthMiddleware` | curl/UI で create 通過 |
+| 停車パターン作成 500（§1-1） | BACKEND | **修正済(追跡)** `StopPatternsService` | curl 201 / UI / `StopPatternApiTest` 10件緑 |
+| 施行日付き Work 作成 500（§1-2） | BACKEND | **修正済(追跡)** `WorksService` | curl 201 / `WorkApiTest` 緑 |
+| ApplyPattern の路線がサンプル（§2-4） | WRONG-SRC | **修正済(追跡)** `App.tsx` を API データへ | work.spec の該当テストが緑転 |
+| `ONLY_FULL_GROUP_BY`（§0-2） | ENV | 暫定(コンテナ `SET PERSIST`、追跡未変更) | sql_mode 確認 |
+| `EMULATE_PREPARES=false`（§0-3） | ENV | 暫定(gitignore `config.inc.php`、追跡テンプレ未変更) | curl create 通過 |
+| エクスポート/インポート（§2-1〜2-3） | WRONG-SRC | **未対応(要設計/機能規模)** | E2E で死を確認 |
+| 時刻表 行 model-only 永続/ドラッグ（§3） | UNIMPL等 | **要設計判断** | ソース確認 |
+
+> **【最重要・オーナー判断】 §0-2/§0-3 — 本番でも create を壊している可能性**:
+> 「設定緩和（masking）」か「クエリ/設定の正規修正」かは未決。現状その回避策は
+> **追跡対象外**（MySQL は実行中コンテナの `SET PERSIST`＝データボリューム寿命、
+> `EMULATE_PREPARES` は gitignore の `config.inc.php`）に置いている。
+> このため **クリーンチェックアウト＋新規ボリュームでは E2E が setup(createProject)
+> で全滅する**（＝スイートは現状このマシンでしか緑にならない）。
+> 推奨する決着のいずれかをオーナーが選ぶ必要がある:
+>   1. **dev/emulator スコープの追跡ファイルに回避策をコミット**して再現可能にする
+>      — `mysql/conf.d/my.cnf` に `sql_mode`(ONLY_FULL_GROUP_BY 除外)、
+>      `config.docker.inc.php` に `EMULATE_PREPARES=true`。いずれも **本 §0 への
+>      コメント付き**で。本番は別の追跡対象外 `config.inc.php` を使うため本番非影響＝
+>      「隠蔽」でなく「開示」。ただし本番クエリが壊れている疑いは §0-2/§0-3 のまま残す。
+>   2. **クエリ/設定を正規修正**（GROUP BY 付与 9 repo / 同名プレースホルダ別名化）。
+> どちらもコードレビュー済みの決定（L5 strict / MySQL strict 既定）に触れるため、
+> **私の独断ではコミットせずオーナー判断に委ねている。**
+
+## E2E スイート状態（`frontend/e2e/`）
+
+- `smoke` / `projects` / `lines`: **安定**（効果＋リロード永続を検証）。`projects` の
+  3 件赤は export/import の WRONG-SOURCE を意図的にエンコード（＝正しく死を検出）。
+  `lines` は停車パターン作成が修正後グリーン化（残 1 件はカードセレクタ厳格性の軽微債務）。
+- `work`: 13/22。緑の主力に加え、§2-4 修正で「サンプル路線を出さない」テストが緑転。
+  残る赤はコンテキストメニュー/⚙ダイアログ/サイドバーのセレクタ債務と、意図的赤の
+  export(WRONG-SOURCE)。**製品バグではないことを実測で確定**: ワーク作成は
+  POST→即時 GET でサイドバーに出現し、DB(`works` テーブル)にも残る（診断スペックで
+  確認済み）。`work.spec` の「リロード後永続」赤は、リロード後の再ナビが works フェッチを
+  安定発火させない**スペック側の債務**で、作成・永続そのものは正常。
+  併せて `createWorkGroup` ヘルパーの strict-mode 違反（「新規WG」2要素マッチ）を
+  `.first()` で修正済み。
+- `timetable`: セットアップ連鎖（Work 作成→列車→グリッド到達）にスペック側の未完があり
+  不安定。**担当エージェントがセッション上限で中断**したため要仕上げ。本 md の §3 所見は
+  ソース（`modelRowToEntityDraft`）から確定済みで、スペック赤に依存しない。
+
+---
+
+## 0. ENV/CONFIG — 開発スタックがミューテーション全滅だった基盤問題
+
+E2E を回す前提として、docker/emulator 構成では **あらゆる作成系 API が失敗**して
+いた。GET（匿名許容＝privilege フィルタ）は 200 を返すため UI 上は「読み込めるのに
+保存できない」状態だった。1 エンドポイント（createProject）で 3 つの独立した失敗が
+連鎖していた。
+
+1. **Firebase 失効チェックが emulator で必ず失敗**
+   `MyAuthMiddleware` は `createProject/deleteProject/deleteWorkGroup/createInviteKey`
+   で `verifyIdToken($token, checkIfRevoked=true)` を呼ぶ。失効チェックは SA 鍵で
+   Firebase に署名リクエストを投げる実装で、emulator 用 SA は意図的なプレースホルダ
+   鍵のため OpenSSL 署名段階で必ず例外 → 401「Invalid authentication token」。
+   - **[修正済]** `backend/src/trvis_backend/auth/MyAuthMiddleware.php`:
+     `FIREBASE_AUTH_EMULATOR_HOST` 設定時のみ失効チェックを無効化（本番は不変）。
+     これは追跡ファイルへのコミット対象（emulator 限定・本番安全）。
+
+2. **`ONLY_FULL_GROUP_BY` で privilege サブクエリが 1140 エラー**
+   多数の repo の SELECT が `MAX(privilege_type)` を非集約列と併用しつつ GROUP BY を
+   省く（例 `ProjectsRepo::selectProjectOne`）。MySQL 8 既定の `ONLY_FULL_GROUP_BY`
+   で `SQLSTATE[42000] 1140` → 500。
+   - **[要対応]** 暫定: 開発 DB で `sql_mode` から `ONLY_FULL_GROUP_BY` を除外
+     （実行中コンテナに `SET PERSIST` 適用済み。追跡ファイル `mysql/conf.d/my.cnf`
+     は**未変更**＝勝手な設定変更を避けるため）。
+   - **恒久案**: 該当サブクエリ（9 repo に同パターン）へ `GROUP BY` を付与。
+     どちらを採るか要判断（設定緩和=masking / クエリ修正≈9ファイル）。
+
+3. **`ATTR_EMULATE_PREPARES=false` で同名プレースホルダ再利用が HY093**
+   `selectProjectOne` 等が `:projects_id` を 1 クエリ内で 2 回使う。native prepare
+   では同名プレースホルダ再利用不可 → `SQLSTATE[HY093] Invalid parameter number`。
+   統合テストは PDO に `EMULATE_PREPARES` を**設定しない**（既定 true）ため、この
+   ドリフトはテストで検出されない。つまり**コミット済み設定では create 系が本当に
+   壊れている**。
+   - **[要対応]** 暫定: ローカル `backend/config/prod/config.inc.php`（gitignore）で
+     `EMULATE_PREPARES=true`。追跡テンプレ `config.docker.inc.php` は**未変更**。
+   - **恒久案**: テンプレ／本番設定を `true` に揃える（テスト harness と一致）か、
+     同名プレースホルダ再利用クエリを別名化。要判断。本番 config が `false` なら
+     **本番でも create が壊れている可能性**があるので最重要。
+
+> 2・3 はコード化された決定（L5 strict / MySQL strict 既定）を覆すため、追跡ファイル
+> への変更は**勝手にコミットせず**ローカル／コンテナ内オーバーライドに留めている。
+> 採用方針（設定緩和か正規修正か）はオーナー判断。
+
+---
+
+## 1. BACKEND-500 — フロントは正しいがサーバが落ちる実バグ（環境非依存）
+
+### 1-1. 停車パターン作成が必ず 500
+`POST /api/v1/projects/{id}/stop_patterns` →
+`StopPatternsService.php:138` が `lines_id` を**文字列のまま**
+`StopPatternsRepo::insertStopPattern()`（`UuidInterface` を要求）に渡す。
+`from_project_stations_id` / `to_project_stations_id`（`?UuidInterface`）も同様。
+ログ: `TypeError: Argument #5 ($linesId) must be of type Ramsey\Uuid\UuidInterface, string given`。
+UI: 路線・駅管理 → 停車パターン → ウィザード「完了」で 500。編集／複製／削除も
+作成不能のため到達不可。
+- **[修正済]** `StopPatternsService` に `asUuid()/asUuidOrNull()` を追加し、
+  `lines_id` / `from`/`to` を string→Uuid 変換（UuidInterface はそのまま通す）。
+  curl で 201、UI でパターンカード表示を確認。`StopPatternApiTest`(10件)グリーン維持。
+
+### 1-2. ワーク作成が施行日(affect_date)付きで 500
+`POST .../work_groups/{id}/works` →
+`WorksService.php:139` が `affect_date` を**文字列のまま**
+`WorksRepo::insertWork()`（`?DateTimeInterface` を要求）に渡す。
+ログ: `TypeError: Argument #6 ($affectDate) must be of type ?DateTimeInterface, string given`。
+WorkDialog は既定で当日日付を入れるため、**通常操作のワーク作成が常に 500**
+（日付を空にすると成功する、という罠）。
+- **[修正済]** `WorksService` の create/update 両経路で
+  `Utils::fromJsonDateOnlyStrToDateTime()` により string→DateTime 変換
+  （DateTimeInterface はそのまま通す）。curl で 201 + `affect_date` 永続確認。
+  `WorkApiTest` グリーン維持。
+
+> 1-1/1-2 は同系統（service 層で request 文字列→型付きオブジェクトの変換漏れ）。
+> 他 create（Project / Line / Station / StationOnLine / Color / 番線 / Train /
+> 時刻表行）は E2E で作成成功を確認済み。
+
+---
+
+## 2. WRONG-SOURCE — メモリ上サンプル `data` を読み書きして実データに繋がらない
+
+App.tsx は API（TanStack Query）から描画する一方、`data = useState(createInitialData())`
+という**サンプルの初期データ**が別に存在し、一部機能がそちらを参照している。
+
+### 2-1. プロジェクト一覧「📤 エクスポート」(ツールバー)
+`exportAll()`（App.tsx:1257）が `data`（サンプル）を JSON 化。作成した実プロジェクト
+ではなく常に同じサンプル（「東海道本線 ダイヤ2024」等）を吐く。E2E でダウンロード
+内容を検証して確認済み。
+- **[修正対象]** API（`apiProjects` ほか）から組み立てる。
+
+### 2-2. プロジェクトカードメニュー「JSONとしてエクスポート」/ サイドバー footer「📤 エクスポート(JSON)」
+`exportProject(pid)`（App.tsx:1242）が `data.projects.find(id===pid)` を引くが、実 ID は
+バックエンド UUID、`data` にはサンプル ID `p1/p2` しか無い → `if(!p) return` で
+**ダウンロードが一切発生しない**。
+- **[修正対象]** API から対象プロジェクトを取得して出力。
+
+### 2-3. プロジェクト一覧「📥 インポート」
+`importJson()`（App.tsx:1273）が `setData(...)` でメモリ状態に書くが、一覧は
+`apiProjects` を描画するため**取り込んでも画面に出ない**（無効果）。
+- **[要設計判断]** API へ POST して取り込むか、`data` を描画ソースにするか。
+
+### 2-4. WorkBrowser / ApplyPatternDialog の路線・経由駅がサンプル
+App.tsx:1490-1491 が WorkBrowser に `stationsOnLine={data.stationsOnLine}` /
+`lines={data.lines}`（サンプル）を渡す。結果、列車のパターン適用ダイアログの路線
+ドロップダウンに実プロジェクトの路線でなくサンプル（l1/l2）が出る。
+- **[修正済(一部)]** App.tsx:1490-1491 を `modelLines` / `modelStationsOnLine`
+  （API 由来）に変更。路線ドロップダウンの実データ化を達成、tsc グリーン。
+  ※ 残課題: `modelStationsOnLine` は選択中 line 単位の取得のため、別 line の
+  パターンの経由駅解決には不足。プロジェクト全体の stationsOnLine 供給は follow-up。
+
+---
+
+## 3. UNIMPLEMENTED / 永続しない（時刻表グリッド）
+
+> timetable/work の E2E スペックは担当エージェントがセッション上限で中断し、
+> セレクタ（`新規列車` が 2 要素にマッチ等）が未修正の失敗が混在する。以下は
+> ソース・ログで裏取りした項目のみ。スペック安定化は別途実施。
+
+### 3-1. 行の詳細「車両到着時刻(alwaysShowHH)」「着/発の非表示」が保存されない
+`modelRowToEntityDraft`（App.tsx:931）に `alwaysShowHh` / `arriveHidden` /
+`departureHidden` 相当が含まれず、編集してもリロードで戻る。
+- **[要設計判断]** バックエンド `timetable_rows` に該当列があるか確認の上、
+  draft に追加（列が無ければ「表示のみ・非永続」が仕様＝バグではない）。
+
+### 3-2. 時刻表行のドラッグ並べ替え
+`.drag-handle` の CSS はあるが `draggable` 等が描画されず並べ替え不可。
+- **[要設計判断]** 並べ替え UI を実装するか、ハンドル表示を削るか。
+
+### 3-3. 行の詳細「作業種別(workType)」が保存されない（実装準備中）
+詳細モーダルに作業種別の自由入力テキストがあるが、リロードで戻る（永続しない）。
+バックエンド側が未実装のため: DB 列 `work_type` は `TINYINT UNSIGNED`、enum
+`WorkAtStationType` は `case none = 0` のみ、OpenAPI も `作業種別 (実装準備中)`
+と明記。文字列（例「荷役」）を TINYINT enum に格納できないため永続不可。
+- **[実装準備中]** バックエンドの enum 拡張または列型変更が必要。フロントは
+  表示のみ（非永続）＝現状はバグではなく未実装。
+  対応 E2E: timetable.spec.ts「detail modal workType is NOT persisted」。
+- **graceful degradation:** `work_type` を送ると backend が
+  `Unknown WorkAtStationType` を返し、**行全体の保存が失敗**して同時編集した
+  他フィールドも失われていた。そのため `toApiTimetableRow` の送信ペイロードから
+  `work_type` を除外し、showHH/arriveHidden と同様に「黙って破棄」する挙動に統一。
+  保存自体は成功する。
+- **残課題（要判断）:** 入力欄は依然編集可能だが値は破棄される UX ワート。
+  enum 実装までは入力欄を無効化／非表示にするか要検討。
+
+---
+
+## 4. 確認済み・正常 (OK)
+
+E2E で効果（多くはリロード後の永続）まで確認:
+プロジェクト 作成/編集/削除/開く/カードメニュー・右クリック、サイドバー WG/ワーク
+作成・編集・削除・コンテキストメニュー、画面遷移（路線・駅／色マーカー）、列車 作成
+（日付罠を回避すれば）・編集・削除・選択、路線 追加/編集/削除、駅 追加/編集/削除、
+経由駅 追加/編集/削除/**ドラッグ並べ替え**、番線 追加/編集/削除、色マーカー（未走査）、
+時刻表行 追加/各セル編集/通過・備考トグル/削除/色（概ね）。
+
+## 5. 未走査（カバレッジの穴）
+担当エージェント未起動／中断のため未検証。要追加 E2E:
+- 色マーカー管理（ColorManager）の全操作
+- 停車パターンウィザード内部（ステップ next/back/完了、行構築）※作成は 1-1 で 500
+- ApplyPatternDialog 内部（パターン適用の最終効果＝列車＋時刻表行生成）
+- AppShell（🌙 テーマ / JP・EN 言語切替 / パンくず）
+- 認証まわり（AccountSettingDialog サインアウト・表示名、EMailVerifyDialog 再送、
+  パスワード再設定、新規登録、パスワード表示切替）

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1957,6 +1957,133 @@
                 ]
             }
         },
+        "/projects/{projectId}/export": {
+            "get": {
+                "tags": [
+                    "project"
+                ],
+                "summary": "エクスポートする",
+                "description": "Project の全グラフ (子エンティティを含む) を1つの ProjectGraph として取得する。\n\nこのProjectへのREAD権限が必要です。",
+                "operationId": "exportProject",
+                "parameters": [
+                    {
+                        "name": "projectId",
+                        "in": "path",
+                        "description": "ProjectのID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "取得成功",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProjectGraph"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "リクエストが不正 (Projectが大きすぎる等)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorData"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "認証トークンのエラー",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorData"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "コンテンツが存在しない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorData"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/projects/import": {
+            "post": {
+                "tags": [
+                    "project"
+                ],
+                "summary": "インポートする",
+                "description": "ProjectGraph を読み込み、新しい Project として全グラフを複製する。すべての id はサーバ側で再採番される。\n\nこの操作にはサインインが必要です。",
+                "operationId": "importProject",
+                "requestBody": {
+                    "description": "インポートする ProjectGraph",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProjectGraph"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "作成成功 (作成された Project を返す)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Project"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "リクエストが不正 (payloadが大きすぎる等)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorData"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "認証トークンのエラー",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorData"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
         "/projects/{projectId}/privileges": {
             "get": {
                 "tags": [
@@ -6834,6 +6961,84 @@
                         ],
                         "readOnly": true,
                         "example": "admin"
+                    }
+                },
+                "type": "object"
+            },
+            "ProjectGraph": {
+                "description": "Project の全グラフ (エクスポート/インポート用バックアップ)。子エンティティは依存順の配列として平坦に保持され、インポート時に全 id はサーバ側で再採番される。",
+                "required": [
+                    "project"
+                ],
+                "properties": {
+                    "project": {
+                        "$ref": "#/components/schemas/Project"
+                    },
+                    "colors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Color"
+                        }
+                    },
+                    "stations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Station"
+                        }
+                    },
+                    "station_tracks": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StationTrack"
+                        }
+                    },
+                    "lines": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Line"
+                        }
+                    },
+                    "stations_on_line": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StationOnLine"
+                        }
+                    },
+                    "stop_patterns": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StopPattern"
+                        }
+                    },
+                    "stop_pattern_rows": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StopPatternRow"
+                        }
+                    },
+                    "work_groups": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/WorkGroup"
+                        }
+                    },
+                    "works": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Work"
+                        }
+                    },
+                    "trains": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Train"
+                        }
+                    },
+                    "timetable_rows": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/TimetableRow"
+                        }
                     }
                 },
                 "type": "object"

--- a/backend/src/trvis_backend/Utils.php
+++ b/backend/src/trvis_backend/Utils.php
@@ -243,6 +243,33 @@ final class Utils
 	}
 
 	/**
+	 * Like getValueOrNull, but does NOT collapse a literal `false` to null.
+	 * getValue() returns the bool `false` both for an absent key AND for a
+	 * present `false` value, so getValueOrNull can't tell them apart — fine for
+	 * most fields, but it silently nulls a present `is_pass: false` etc., which
+	 * then violates the NOT NULL boolean columns on UPDATE. Use this for those
+	 * fields: it preserves `false` and only yields null when the key is truly
+	 * absent (or explicitly null).
+	 */
+	public static function getBoolValueOrNull(mixed $d, string $key): ?bool
+	{
+		if (is_object($d)) {
+			if (!property_exists($d, $key)) {
+				return null;
+			}
+			$v = $d->{$key};
+		} elseif (is_array($d)) {
+			if (!array_key_exists($key, $d)) {
+				return null;
+			}
+			$v = $d[$key];
+		} else {
+			return null;
+		}
+		return is_null($v) ? null : (bool)$v;
+	}
+
+	/**
 	 * @param array<string> $keys
 	 * @return array<string, string|int>
 	 */

--- a/backend/src/trvis_backend/api/ProjectApi.php
+++ b/backend/src/trvis_backend/api/ProjectApi.php
@@ -8,6 +8,7 @@ use dev_t0r\trvis_backend\auth\MyAuthMiddleware;
 use dev_t0r\trvis_backend\Constants;
 use dev_t0r\trvis_backend\model\InviteKeyPrivilegeType;
 use dev_t0r\trvis_backend\service\ProjectsService;
+use dev_t0r\trvis_backend\service\ProjectTransferService;
 use dev_t0r\trvis_backend\Utils;
 use dev_t0r\trvis_backend\validator\EnumValidationRule;
 use dev_t0r\trvis_backend\validator\PagingQueryValidator;
@@ -33,6 +34,7 @@ use Ramsey\Uuid\Uuid;
 class ProjectApi
 {
 	private readonly ProjectsService $projectsService;
+	private readonly ProjectTransferService $transferService;
 	private readonly RequestValidator $bodyValidator;
 
 	public function __construct(
@@ -40,6 +42,7 @@ class ProjectApi
 		private readonly LoggerInterface $logger,
 	) {
 		$this->projectsService = new ProjectsService($db, $logger);
+		$this->transferService = new ProjectTransferService($db, $logger);
 		$this->bodyValidator = new RequestValidator(
 			RequestValidator::getDescriptionValidationRule(),
 			RequestValidator::getNameValidationRule(),
@@ -76,11 +79,25 @@ class ProjectApi
 				'name' => 'createProject',
 			],
 			[
+				'methods' => ['POST'],
+				'basePath' => '/api/v1',
+				'path' => '/projects/import',
+				'handler' => [self::class, 'importProject'],
+				'name' => 'importProject',
+			],
+			[
 				'methods' => ['GET'],
 				'basePath' => '/api/v1',
 				'path' => '/projects/{projectId}',
 				'handler' => [self::class, 'getProject'],
 				'name' => 'getProject',
+			],
+			[
+				'methods' => ['GET'],
+				'basePath' => '/api/v1',
+				'path' => '/projects/{projectId}/export',
+				'handler' => [self::class, 'exportProject'],
+				'name' => 'exportProject',
 			],
 			[
 				'methods' => ['PUT'],
@@ -304,6 +321,112 @@ class ProjectApi
 		return $this->projectsService->selectProjectOne(
 			currentUserId: $userId,
 			projectsId: $uuid,
+		)->getResponseWithJson($response);
+	}
+
+	#[OA\Get(
+		path: '/projects/{projectId}/export',
+		operationId: 'exportProject',
+		tags: ['project'],
+		summary: 'エクスポートする',
+		description: "Project の全グラフ (子エンティティを含む) を1つの ProjectGraph として取得する。\n\nこのProjectへのREAD権限が必要です。",
+		security: [['bearerAuth' => []]],
+		parameters: [
+			new OA\PathParameter(
+				name: 'projectId',
+				description: 'ProjectのID',
+				required: true,
+				schema: new OA\Schema(type: 'string', format: 'uuid'),
+			),
+		],
+		responses: [
+			new OA\Response(
+				response: 200,
+				description: '取得成功',
+				content: new OA\JsonContent(ref: '#/components/schemas/ProjectGraph'),
+			),
+			new OA\Response(
+				response: 400,
+				description: 'リクエストが不正 (Projectが大きすぎる等)',
+				content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorData'),
+			),
+			new OA\Response(
+				response: 401,
+				description: '認証トークンのエラー',
+				content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorData'),
+			),
+			new OA\Response(
+				response: 404,
+				description: 'コンテンツが存在しない',
+				content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorData'),
+			),
+		],
+	)]
+	public function exportProject(
+		ServerRequestInterface $request,
+		ResponseInterface $response,
+		string $projectId
+	): ResponseInterface {
+		$userId = MyAuthMiddleware::getUserIdOrAnonymous($request);
+		if (!Uuid::isValid($projectId)) {
+			$this->logger->warning("Invalid UUID format ({projectId})", ['projectId' => $projectId]);
+			return Utils::withUuidError($response);
+		}
+
+		return $this->transferService->export(
+			projectsId: Uuid::fromString($projectId),
+			userId: $userId,
+		)->getResponseWithJson($response);
+	}
+
+	#[OA\Post(
+		path: '/projects/import',
+		operationId: 'importProject',
+		tags: ['project'],
+		summary: 'インポートする',
+		description: "ProjectGraph を読み込み、新しい Project として全グラフを複製する。すべての id はサーバ側で再採番される。\n\nこの操作にはサインインが必要です。",
+		security: [['bearerAuth' => []]],
+		requestBody: new OA\RequestBody(
+			description: 'インポートする ProjectGraph',
+			required: true,
+			content: new OA\JsonContent(ref: '#/components/schemas/ProjectGraph'),
+		),
+		responses: [
+			new OA\Response(
+				response: 201,
+				description: '作成成功 (作成された Project を返す)',
+				content: new OA\JsonContent(ref: '#/components/schemas/Project'),
+			),
+			new OA\Response(
+				response: 400,
+				description: 'リクエストが不正 (payloadが大きすぎる等)',
+				content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorData'),
+			),
+			new OA\Response(
+				response: 401,
+				description: '認証トークンのエラー',
+				content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorData'),
+			),
+		],
+	)]
+	public function importProject(
+		ServerRequestInterface $request,
+		ResponseInterface $response
+	): ResponseInterface {
+		$userId = MyAuthMiddleware::getUserIdOrNull($request);
+		if ($userId === null) {
+			$this->logger->warning("Token was not set");
+			return Utils::withError($response, Constants::HTTP_UNAUTHORIZED, "Token was not set");
+		}
+
+		$body = $request->getParsedBody();
+		if (!is_array($body) && !is_object($body)) {
+			return Utils::withError($response, Constants::HTTP_BAD_REQUEST, "Invalid request body");
+		}
+
+		return $this->transferService->import(
+			userId: $userId,
+			graph: $body,
 		)->getResponseWithJson($response);
 	}
 

--- a/backend/src/trvis_backend/api/TimetableRowApi.php
+++ b/backend/src/trvis_backend/api/TimetableRowApi.php
@@ -620,10 +620,13 @@ class TimetableRowApi
 			'description' => Utils::getValueOrNull($body, 'description'),
 			'drive_time_mm' => Utils::getValueOrNull($body, 'drive_time_mm'),
 			'drive_time_ss' => Utils::getValueOrNull($body, 'drive_time_ss'),
-			'is_operation_only_stop' => Utils::getValueOrNull($body, 'is_operation_only_stop'),
-			'is_pass' => Utils::getValueOrNull($body, 'is_pass'),
-			'has_bracket' => Utils::getValueOrNull($body, 'has_bracket'),
-			'is_last_stop' => Utils::getValueOrNull($body, 'is_last_stop'),
+			// Use getBoolValueOrNull: getValueOrNull collapses a present
+			// `false` to null (getValue's absent-sentinel is also false), which
+			// would NULL these NOT NULL columns on UPDATE → SQLSTATE 23000.
+			'is_operation_only_stop' => Utils::getBoolValueOrNull($body, 'is_operation_only_stop'),
+			'is_pass' => Utils::getBoolValueOrNull($body, 'is_pass'),
+			'has_bracket' => Utils::getBoolValueOrNull($body, 'has_bracket'),
+			'is_last_stop' => Utils::getBoolValueOrNull($body, 'is_last_stop'),
 			'arrive_time_hh' => Utils::getValueOrNull($body, 'arrive_time_hh'),
 			'arrive_time_mm' => Utils::getValueOrNull($body, 'arrive_time_mm'),
 			'arrive_time_ss' => Utils::getValueOrNull($body, 'arrive_time_ss'),

--- a/backend/src/trvis_backend/auth/MyAuthMiddleware.php
+++ b/backend/src/trvis_backend/auth/MyAuthMiddleware.php
@@ -54,6 +54,17 @@ final class MyAuthMiddleware implements MiddlewareInterface
 				$routeName = RouteContext::fromRequest($request)->getRoute()?->getName();
 				$checkIfRevoked = $routeName !== null
 					&& in_array($routeName, self::ROUTES_REQUIRING_REVOCATION_CHECK, true);
+				// 失効チェック (verifyIdToken の第2引数) は、SA 鍵で署名した
+				// リクエストを Firebase の Secure Token API に投げてユーザーの
+				// 失効状態を引く実装。Auth Emulator にはその基盤が無く、かつ
+				// emulator 用 SA は意図的なプレースホルダ鍵 (非 PEM) なので、
+				// 失効チェックを行うと OpenSSL の署名段階で必ず例外になり、
+				// createProject 等 ROUTES_REQUIRING_REVOCATION_CHECK の経路が
+				// emulator 環境で常に 401 になる。emulator 利用時は失効チェックを
+				// 無効化する (dev/test 専用。本番= emulator host 未設定では従来通り)。
+				if (getenv('FIREBASE_AUTH_EMULATOR_HOST') !== false) {
+					$checkIfRevoked = false;
+				}
 				$verifiedIdToken = $this->auth->verifyIdToken($tokenStr, $checkIfRevoked);
 
 				$request = $request->withAttribute($this::ATTR_NAME_TOKEN_OBJ, $verifiedIdToken);

--- a/backend/src/trvis_backend/model/ProjectGraph.php
+++ b/backend/src/trvis_backend/model/ProjectGraph.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace dev_t0r\trvis_backend\model;
+
+use OpenApi\Attributes as OA;
+
+/**
+ * ProjectGraph — the export/import envelope for a whole Project graph.
+ *
+ * This is a FLAT bundle: `project` plus one array per child entity type, each
+ * array carrying that entity's normal schema object (the same shape the per-
+ * entity GET endpoints return). Import walks the arrays in dependency order
+ * and remaps every id server-side, so the envelope deliberately keeps the
+ * original (readOnly) ids — they are the remap keys, not authoritative.
+ *
+ * Attribute-only (no BaseModel): the service builds the response as a plain
+ * array of already-serializable models, so there is no runtime instance to
+ * carry OAS_PROPERTIES. swagger-php reads the #[OA\Schema] below regardless.
+ */
+#[OA\Schema(
+	schema: 'ProjectGraph',
+	type: 'object',
+	required: ['project'],
+	description: 'Project の全グラフ (エクスポート/インポート用バックアップ)。子エンティティは依存順の配列として平坦に保持され、インポート時に全 id はサーバ側で再採番される。',
+	properties: [
+		new OA\Property(property: 'project', ref: '#/components/schemas/Project'),
+		new OA\Property(property: 'colors', type: 'array', items: new OA\Items(ref: '#/components/schemas/Color')),
+		new OA\Property(property: 'stations', type: 'array', items: new OA\Items(ref: '#/components/schemas/Station')),
+		new OA\Property(property: 'station_tracks', type: 'array', items: new OA\Items(ref: '#/components/schemas/StationTrack')),
+		new OA\Property(property: 'lines', type: 'array', items: new OA\Items(ref: '#/components/schemas/Line')),
+		new OA\Property(property: 'stations_on_line', type: 'array', items: new OA\Items(ref: '#/components/schemas/StationOnLine')),
+		new OA\Property(property: 'stop_patterns', type: 'array', items: new OA\Items(ref: '#/components/schemas/StopPattern')),
+		new OA\Property(property: 'stop_pattern_rows', type: 'array', items: new OA\Items(ref: '#/components/schemas/StopPatternRow')),
+		new OA\Property(property: 'work_groups', type: 'array', items: new OA\Items(ref: '#/components/schemas/WorkGroup')),
+		new OA\Property(property: 'works', type: 'array', items: new OA\Items(ref: '#/components/schemas/Work')),
+		new OA\Property(property: 'trains', type: 'array', items: new OA\Items(ref: '#/components/schemas/Train')),
+		new OA\Property(property: 'timetable_rows', type: 'array', items: new OA\Items(ref: '#/components/schemas/TimetableRow')),
+	],
+)]
+final class ProjectGraph
+{
+}

--- a/backend/src/trvis_backend/repo/ColorsRepo.php
+++ b/backend/src/trvis_backend/repo/ColorsRepo.php
@@ -411,9 +411,9 @@ final class ColorsRepo implements IMyRepoSelectPrivilegeType
 				fn ($i) => <<<SQL
 					(
 						:colors_id_{$i},
-						:projects_id,
+						:projects_id_{$i},
 						:description_{$i},
-						:owner,
+						:owner_{$i},
 						:name_{$i},
 						:red_8bit_{$i},
 						:green_8bit_{$i},
@@ -445,10 +445,13 @@ final class ColorsRepo implements IMyRepoSelectPrivilegeType
 				;
 				SQL
 			);
-			$query->bindValue(':projects_id', $projectsId->getBytes(), PDO::PARAM_STR);
-			$query->bindValue(':owner', $owner, PDO::PARAM_STR);
-
+			// Per-row placeholders for projects_id / owner: under native prepares
+			// (EMULATE_PREPARES=false) a named placeholder may appear only once
+			// in the statement, so the shared :projects_id / :owner reused across
+			// every VALUES tuple was an HY093 for any bulk (N>1) insert.
 			foreach ($dataList as $i => $d) {
+				$query->bindValue(":projects_id_$i", $projectsId->getBytes(), PDO::PARAM_STR);
+				$query->bindValue(":owner_$i", $owner, PDO::PARAM_STR);
 				$query->bindValue(":colors_id_$i", $insertIdList[$i]->getBytes(), PDO::PARAM_STR);
 				$query->bindValue(":description_$i", $d->description, PDO::PARAM_STR);
 				$query->bindValue(":name_$i", $d->name, PDO::PARAM_STR);

--- a/backend/src/trvis_backend/repo/ProjectsRepo.php
+++ b/backend/src/trvis_backend/repo/ProjectsRepo.php
@@ -71,12 +71,12 @@ final class ProjectsRepo
 					$WHERE_USER_ID
 				AND
 					$WHERE_PRIVILEGE_TYPE
+				GROUP BY
+					projects_id
 				) AS projects_privileges
 			USING
 				(projects_id)
 			WHERE
-				projects.projects_id = :projects_id
-			AND
 				projects.deleted_at IS NULL
 			;
 			SQL

--- a/backend/src/trvis_backend/repo/StationsOnLineRepo.php
+++ b/backend/src/trvis_backend/repo/StationsOnLineRepo.php
@@ -512,7 +512,7 @@ final class StationsOnLineRepo implements IMyRepoSelectPrivilegeType
 				track_hidden_by_default
 			) VALUES (
 				:stations_on_line_id,
-				(SELECT pl.projects_id FROM project_lines pl WHERE pl.project_lines_id = :lines_id),
+				(SELECT pl.projects_id FROM project_lines pl WHERE pl.project_lines_id = :lines_id_for_projects),
 				:lines_id,
 				:project_stations_id,
 				:owner,
@@ -524,6 +524,9 @@ final class StationsOnLineRepo implements IMyRepoSelectPrivilegeType
 		);
 		$query->bindValue(':stations_on_line_id', $stationOnLineId->getBytes(), PDO::PARAM_STR);
 		$query->bindValue(':lines_id', $linesId->getBytes(), PDO::PARAM_STR);
+		// Native prepares (EMULATE_PREPARES=false) forbid reusing a named
+		// placeholder; the projects_id subquery binds the same value separately.
+		$query->bindValue(':lines_id_for_projects', $linesId->getBytes(), PDO::PARAM_STR);
 		$query->bindValue(':project_stations_id', $projectStationsId->getBytes(), PDO::PARAM_STR);
 		$query->bindValue(':owner', $owner, PDO::PARAM_STR);
 		$query->bindValue(':location_m', $locationM, PDO::PARAM_STR);

--- a/backend/src/trvis_backend/repo/StopPatternRowsRepo.php
+++ b/backend/src/trvis_backend/repo/StopPatternRowsRepo.php
@@ -537,7 +537,7 @@ final class StopPatternRowsRepo implements IMyRepoSelectPrivilegeType
 			) VALUES (
 				:stop_pattern_rows_id,
 				:stop_patterns_id,
-				(SELECT sp.projects_id FROM stop_patterns sp WHERE sp.stop_patterns_id = :stop_patterns_id),
+				(SELECT sp.projects_id FROM stop_patterns sp WHERE sp.stop_patterns_id = :stop_patterns_id_for_projects),
 				:project_stations_id,
 				:owner,
 				:sort_key,
@@ -563,6 +563,9 @@ final class StopPatternRowsRepo implements IMyRepoSelectPrivilegeType
 
 		$query->bindValue(':stop_pattern_rows_id', $stopPatternRowId->getBytes(), PDO::PARAM_STR);
 		$query->bindValue(':stop_patterns_id', $stopPatternsId->getBytes(), PDO::PARAM_STR);
+		// Native prepares forbid reusing a named placeholder; the projects_id
+		// subquery binds the same value under a distinct name.
+		$query->bindValue(':stop_patterns_id_for_projects', $stopPatternsId->getBytes(), PDO::PARAM_STR);
 		$query->bindValue(':project_stations_id', $projectStationsId->getBytes(), PDO::PARAM_STR);
 		$query->bindValue(':owner', $owner, PDO::PARAM_STR);
 		$query->bindValue(':sort_key', $sortKey, PDO::PARAM_INT);

--- a/backend/src/trvis_backend/repo/TimetableRowsRepo.php
+++ b/backend/src/trvis_backend/repo/TimetableRowsRepo.php
@@ -36,11 +36,10 @@ use Ramsey\Uuid\UuidInterface;
  *   - update() has NO column allowlist and NO explicit updated_at set —
  *     it is a literal port of MyRepoBase::update. The kvpArray is already
  *     filtered to the 22 model keys by the service's getArrayForUpdateSource.
- *   - The `colors_id_marker` field maps to the DB column `colors_id` on
- *     INSERT (correct), but legacy update() emits the SET line
- *     `colors_id_marker = :colors_id_marker` for that key — MySQL rejects
- *     it ("Unknown column 'colors_id_marker'") → caught → HTTP 500. This
- *     is a legacy bug reproduced 1:1; a fix belongs in a post-migration PR.
+ *   - The `colors_id_marker` model/kvp key maps to the DB column `colors_id`
+ *     (as on INSERT). update() now remaps that one SET column name (see the
+ *     $keyToColumn map below) — previously it emitted `colors_id_marker = ...`
+ *     and MySQL rejected it ("Unknown column") → HTTP 500.
  *
  * Method names must NOT have a leading underscore (PSR2.Methods — not in
  * the 4-exclude carve-out). Canonical precedent: TrainsRepo / WorksRepo.
@@ -821,10 +820,14 @@ final class TimetableRowsRepo implements IMyRepoSelectPrivilegeType
 			['timetableRowsId' => $timetableRowsId],
 		);
 
+		// The model/kvp key `colors_id_marker` maps to the DB column `colors_id`
+		// (matching the INSERT path). Remap only the SET column name; the bound
+		// placeholder keeps the kvp key, so the bind loop below is unaffected.
+		$keyToColumn = ['colors_id_marker' => 'colors_id'];
 		$setClause = implode(
 			', ',
 			array_map(
-				fn ($key) => "{$key} = :{$key}",
+				fn ($key) => ($keyToColumn[$key] ?? $key) . " = :{$key}",
 				array_keys($kvpArray),
 			),
 		);
@@ -857,7 +860,12 @@ final class TimetableRowsRepo implements IMyRepoSelectPrivilegeType
 				} elseif (is_int($newValue)) {
 					$paramType = PDO::PARAM_INT;
 				} elseif (is_bool($newValue)) {
-					$paramType = PDO::PARAM_BOOL;
+					// The boolean columns are `tinyint(1) NOT NULL`. With native
+					// (non-emulated) prepares, PDO::PARAM_BOOL binds `false` as an
+					// empty string on this UPDATE path, violating NOT NULL (SQLSTATE
+					// 23000). Bind the explicit 0/1 int instead (matches tinyint).
+					$newValue = $newValue ? 1 : 0;
+					$paramType = PDO::PARAM_INT;
 				}
 
 				$query->bindValue(":{$key}", $newValue, $paramType);

--- a/backend/src/trvis_backend/service/ProjectTransferService.php
+++ b/backend/src/trvis_backend/service/ProjectTransferService.php
@@ -1,0 +1,667 @@
+<?php
+
+declare(strict_types=1);
+
+namespace dev_t0r\trvis_backend\service;
+
+use dev_t0r\trvis_backend\Constants;
+use dev_t0r\trvis_backend\model\Color;
+use dev_t0r\trvis_backend\model\InviteKeyPrivilegeType;
+use dev_t0r\trvis_backend\model\StationLocationLonlat;
+use dev_t0r\trvis_backend\model\StationOnLineLocationLonlat;
+use dev_t0r\trvis_backend\model\StationRecordType;
+use dev_t0r\trvis_backend\model\TrvisContentType;
+use dev_t0r\trvis_backend\model\WorkAtStationType;
+use dev_t0r\trvis_backend\repo\ColorsRepo;
+use dev_t0r\trvis_backend\repo\LineRepo;
+use dev_t0r\trvis_backend\repo\ProjectsPrivilegesRepo;
+use dev_t0r\trvis_backend\repo\ProjectsRepo;
+use dev_t0r\trvis_backend\repo\StationsOnLineRepo;
+use dev_t0r\trvis_backend\repo\StationsRepo;
+use dev_t0r\trvis_backend\repo\StationTracksRepo;
+use dev_t0r\trvis_backend\repo\StopPatternRowsRepo;
+use dev_t0r\trvis_backend\repo\StopPatternsRepo;
+use dev_t0r\trvis_backend\repo\TimetableRowsRepo;
+use dev_t0r\trvis_backend\repo\TrainsRepo;
+use dev_t0r\trvis_backend\repo\WorkGroupsRepo;
+use dev_t0r\trvis_backend\repo\WorksRepo;
+use dev_t0r\trvis_backend\RetValueOrError;
+use dev_t0r\trvis_backend\Utils;
+use PDO;
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * ProjectTransferService — dedicated whole-Project export/import.
+ *
+ * Export aggregates every entity under a Project into one flat ProjectGraph
+ * envelope in a single (consistent-snapshot) read transaction. Import recreates
+ * the entire graph under a brand-new Project in ONE write transaction, with a
+ * server-side old→new id remap so the new project is fully self-consistent and
+ * independent of the source.
+ *
+ * Reads go straight to the repos with a large perPage (not the 100-row API
+ * paging limit) so a real project never silently truncates on export. Both
+ * directions are capped (EXPORT_MAX_ROWS / IMPORT_MAX_ROWS) and a too-large
+ * payload is a clean 400, never a hang.
+ *
+ * Dangling-FK policy (a child may reference a soft-deleted parent that the
+ * deleted_at-filtered reads omit): a row whose REQUIRED parent id can't be
+ * remapped is SKIPPED and counted in `skipped` (never a silent loss, never a
+ * NOT NULL abort); a NULLABLE dangling FK is dropped to null.
+ */
+final class ProjectTransferService
+{
+	/** read ceiling per select; a project hitting this exports as 400 (too large) */
+	private const EXPORT_MAX_ROWS = 100000;
+	/** total-rows ceiling for a single import payload */
+	private const IMPORT_MAX_ROWS = 100000;
+
+	private readonly ProjectsRepo $projectsRepo;
+	private readonly ProjectsPrivilegesRepo $projectsPrivilegesRepo;
+	private readonly ColorsRepo $colorsRepo;
+	private readonly StationsRepo $stationsRepo;
+	private readonly StationTracksRepo $stationTracksRepo;
+	private readonly LineRepo $lineRepo;
+	private readonly StationsOnLineRepo $stationsOnLineRepo;
+	private readonly StopPatternsRepo $stopPatternsRepo;
+	private readonly StopPatternRowsRepo $stopPatternRowsRepo;
+	private readonly WorkGroupsRepo $workGroupsRepo;
+	private readonly WorksRepo $worksRepo;
+	private readonly TrainsRepo $trainsRepo;
+	private readonly TimetableRowsRepo $timetableRowsRepo;
+
+	public function __construct(
+		private readonly PDO $db,
+		private readonly LoggerInterface $logger,
+	) {
+		$this->projectsRepo = new ProjectsRepo($db, $logger);
+		$this->projectsPrivilegesRepo = new ProjectsPrivilegesRepo($db, $logger);
+		$this->colorsRepo = new ColorsRepo($db, $logger);
+		$this->stationsRepo = new StationsRepo($db, $logger);
+		$this->stationTracksRepo = new StationTracksRepo($db, $logger);
+		$this->lineRepo = new LineRepo($db, $logger);
+		$this->stationsOnLineRepo = new StationsOnLineRepo($db, $logger);
+		$this->stopPatternsRepo = new StopPatternsRepo($db, $logger);
+		$this->stopPatternRowsRepo = new StopPatternRowsRepo($db, $logger);
+		$this->workGroupsRepo = new WorkGroupsRepo($db, $logger);
+		$this->worksRepo = new WorksRepo($db, $logger);
+		$this->trainsRepo = new TrainsRepo($db, $logger);
+		$this->timetableRowsRepo = new TimetableRowsRepo($db, $logger);
+	}
+
+	// ───────────────────────────── EXPORT ─────────────────────────────
+
+	/**
+	 * Aggregate the whole graph under $projectsId into a flat ProjectGraph.
+	 *
+	 * @return RetValueOrError<array<string,mixed>>
+	 */
+	public function export(
+		UuidInterface $projectsId,
+		string $userId,
+	): RetValueOrError {
+		$this->logger->debug(
+			"export(projectsId:{projectsId}, userId:{userId})",
+			['projectsId' => $projectsId, 'userId' => $userId],
+		);
+
+		$privResult = $this->projectsPrivilegesRepo->selectPrivilegeType(
+			id: $projectsId,
+			userId: $userId,
+			includeAnonymous: true,
+		);
+		if ($privResult->isError) {
+			return $privResult;
+		}
+		if (!$privResult->value->hasPrivilege(InviteKeyPrivilegeType::read)) {
+			return Utils::errProjectNotFound();
+		}
+
+		$projectResult = $this->projectsRepo->selectProjectOne($userId, $projectsId);
+		if ($projectResult->isError) {
+			return $projectResult;
+		}
+
+		// Consistent-snapshot read (REPEATABLE READ) so cross-entity paging
+		// can't tear under a concurrent writer.
+		$this->db->beginTransaction();
+		try {
+			$colors = $this->unwrap($this->colorsRepo->selectPage($projectsId, 1, self::EXPORT_MAX_ROWS, null));
+			$stations = $this->unwrap($this->stationsRepo->selectStationPage($projectsId, $userId, 1, self::EXPORT_MAX_ROWS, null));
+			$lines = $this->unwrap($this->lineRepo->selectLinePage($userId, $projectsId, 1, self::EXPORT_MAX_ROWS, null));
+			$stopPatterns = $this->unwrap($this->stopPatternsRepo->selectStopPatternPage($projectsId, $userId, 1, self::EXPORT_MAX_ROWS, null));
+			$workGroups = $this->unwrap($this->workGroupsRepo->selectWorkGroupPageByProjectId($projectsId, $userId, 1, self::EXPORT_MAX_ROWS, null));
+
+			$stationTracks = [];
+			foreach ($stations as $st) {
+				foreach ($this->unwrap($this->stationTracksRepo->selectStationTrackPage($st->stations_id, $userId, 1, self::EXPORT_MAX_ROWS, null)) as $t) {
+					$stationTracks[] = $t;
+				}
+			}
+			$stationsOnLine = [];
+			foreach ($lines as $ln) {
+				foreach ($this->unwrap($this->stationsOnLineRepo->selectStationOnLinePage($ln->lines_id, $userId, 1, self::EXPORT_MAX_ROWS, null)) as $sol) {
+					$stationsOnLine[] = $sol;
+				}
+			}
+			$stopPatternRows = [];
+			foreach ($stopPatterns as $sp) {
+				foreach ($this->unwrap($this->stopPatternRowsRepo->selectStopPatternRowPage($sp->stop_patterns_id, $userId, 1, self::EXPORT_MAX_ROWS, null)) as $r) {
+					$stopPatternRows[] = $r;
+				}
+			}
+			$works = [];
+			foreach ($workGroups as $wg) {
+				foreach ($this->unwrap($this->worksRepo->selectWorkPage($wg->work_groups_id, $userId, 1, self::EXPORT_MAX_ROWS, null)) as $w) {
+					$works[] = $w;
+				}
+			}
+			$trains = [];
+			foreach ($works as $w) {
+				foreach ($this->unwrap($this->trainsRepo->selectTrainPage($w->works_id, 1, self::EXPORT_MAX_ROWS, null)) as $t) {
+					$trains[] = $t;
+				}
+			}
+			$timetableRows = [];
+			foreach ($trains as $t) {
+				foreach ($this->unwrap($this->timetableRowsRepo->selectTimetableRowPage($t->trains_id, 1, self::EXPORT_MAX_ROWS, null)) as $r) {
+					$timetableRows[] = $r;
+				}
+			}
+
+			$this->db->commit();
+		} catch (\Throwable $e) {
+			if ($this->db->inTransaction()) {
+				$this->db->rollBack();
+			}
+			$this->logger->error("export failed: {exception}", ['exception' => $e]);
+			if ($e instanceof TransferTooLargeException) {
+				return RetValueOrError::withError(Constants::HTTP_BAD_REQUEST, $e->getMessage());
+			}
+			return RetValueOrError::withError(Constants::HTTP_INTERNAL_SERVER_ERROR, 'export failed');
+		}
+
+		$graph = [
+			'project' => $projectResult->value,
+			'colors' => $colors,
+			'stations' => $stations,
+			'station_tracks' => $stationTracks,
+			'lines' => $lines,
+			'stations_on_line' => $stationsOnLine,
+			'stop_patterns' => $stopPatterns,
+			'stop_pattern_rows' => $stopPatternRows,
+			'work_groups' => $workGroups,
+			'works' => $works,
+			'trains' => $trains,
+			'timetable_rows' => $timetableRows,
+		];
+		return RetValueOrError::withValue($graph);
+	}
+
+	/**
+	 * Unwrap a select RetValueOrError to its array, throwing on error / cap so
+	 * the export transaction aborts cleanly.
+	 *
+	 * @return array<object>
+	 */
+	private function unwrap(RetValueOrError $r): array
+	{
+		if ($r->isError) {
+			throw new \RuntimeException("select failed: [{$r->statusCode}] {$r->errorMsg}");
+		}
+		$list = $r->value;
+		if (count($list) >= self::EXPORT_MAX_ROWS) {
+			throw new TransferTooLargeException(
+				"Project is too large to export (an entity exceeds " . self::EXPORT_MAX_ROWS . " rows)",
+			);
+		}
+		return $list;
+	}
+
+	// ───────────────────────────── IMPORT ─────────────────────────────
+
+	/**
+	 * Recreate $graph as a brand-new Project owned by $userId in one
+	 * transaction. Returns the new Project (201) on success.
+	 *
+	 * @param array<string,mixed>|object $graph the parsed ProjectGraph body
+	 * @return RetValueOrError<object>
+	 */
+	public function import(
+		string $userId,
+		mixed $graph,
+	): RetValueOrError {
+		$this->logger->debug("import(userId:{userId})", ['userId' => $userId]);
+
+		$project = Utils::getValueOrNull($graph, 'project');
+		if (is_null($project)) {
+			return RetValueOrError::withError(Constants::HTTP_BAD_REQUEST, "'project' is required");
+		}
+
+		$colors = $this->listOf($graph, 'colors');
+		$stations = $this->listOf($graph, 'stations');
+		$stationTracks = $this->listOf($graph, 'station_tracks');
+		$lines = $this->listOf($graph, 'lines');
+		$stationsOnLine = $this->listOf($graph, 'stations_on_line');
+		$stopPatterns = $this->listOf($graph, 'stop_patterns');
+		$stopPatternRows = $this->listOf($graph, 'stop_pattern_rows');
+		$workGroups = $this->listOf($graph, 'work_groups');
+		$works = $this->listOf($graph, 'works');
+		$trains = $this->listOf($graph, 'trains');
+		$timetableRows = $this->listOf($graph, 'timetable_rows');
+
+		$total = count($colors) + count($stations) + count($stationTracks) + count($lines)
+			+ count($stationsOnLine) + count($stopPatterns) + count($stopPatternRows)
+			+ count($workGroups) + count($works) + count($trains) + count($timetableRows);
+		if ($total > self::IMPORT_MAX_ROWS) {
+			return RetValueOrError::withError(
+				Constants::HTTP_BAD_REQUEST,
+				"Import payload is too large. Max total rows is " . self::IMPORT_MAX_ROWS,
+			);
+		}
+
+		// old-id (string) → new UuidInterface
+		$colorMap = [];
+		$stationMap = [];
+		$stationTrackMap = [];
+		$lineMap = [];
+		$stopPatternMap = [];
+		$workGroupMap = [];
+		$workMap = [];
+		$trainMap = [];
+		$skipped = 0;
+
+		$this->db->beginTransaction();
+		try {
+			// 1. Project + owner-admin privilege (mirrors ProjectsService::createProject)
+			$newProjectId = Uuid::uuid7();
+			$this->ok($this->projectsRepo->insertProject(
+				projectId: $newProjectId,
+				owner: $userId,
+				name: (string)(Utils::getValueOrNull($project, 'name') ?? ''),
+				description: (string)(Utils::getValueOrNull($project, 'description') ?? ''),
+			));
+			$this->ok($this->projectsPrivilegesRepo->insert(
+				projectsId: $newProjectId,
+				userId: $userId,
+				privilegeType: InviteKeyPrivilegeType::admin,
+			));
+
+			// 2. Colors (bulk insert via model list, like ColorsService::create)
+			if (!empty($colors)) {
+				$colorIds = [];
+				$colorModels = [];
+				foreach ($colors as $c) {
+					$colorIds[] = Uuid::uuid7();
+					$m = new Color();
+					$m->setData([
+						'name' => Utils::getValueOrNull($c, 'name'),
+						'description' => Utils::getValueOrNull($c, 'description'),
+						// ColorsRepo::insertList reads `color_8bit->red` (object
+						// access); Slim's body parser yields assoc arrays, so
+						// coerce to stdClass to stay parser-agnostic.
+						'color_8bit' => $this->toObjOrNull(Utils::getValueOrNull($c, 'color_8bit')),
+						'color_real' => $this->toObjOrNull(Utils::getValueOrNull($c, 'color_real')),
+					]);
+					$colorModels[] = $m;
+				}
+				$this->ok($this->colorsRepo->insertList(
+					projectsId: $newProjectId,
+					owner: $userId,
+					insertIdList: $colorIds,
+					dataList: $colorModels,
+					db: $this->db,
+				));
+				foreach ($colors as $i => $c) {
+					$colorMap[(string)Utils::getValueOrNull($c, 'colors_id')] = $colorIds[$i];
+				}
+			}
+
+			// 3. Stations
+			foreach ($stations as $s) {
+				$newId = Uuid::uuid7();
+				$this->ok($this->stationsRepo->insertStation(
+					stationsId: $newId,
+					projectsId: $newProjectId,
+					owner: $userId,
+					name: (string)Utils::getValueOrNull($s, 'name'),
+					fullName: Utils::getValueOrNull($s, 'full_name'),
+					locationKm: Utils::floatvalOrNull(Utils::getValueOrNull($s, 'location_km')) ?? 0.0,
+					locationLonlat: $this->parseStationLonlat($s),
+					onStationDetectRadiusM: Utils::floatvalOrNull(Utils::getValueOrNull($s, 'on_station_detect_radius_m')),
+					recordType: StationRecordType::fromOrNull(Utils::getValueOrNull($s, 'record_type')) ?? StationRecordType::normal,
+					alwaysShowHh: boolval(Utils::getValueOrNull($s, 'always_show_hh')),
+				));
+				$stationMap[(string)Utils::getValueOrNull($s, 'stations_id')] = $newId;
+			}
+
+			// 4. Station tracks (child of station — required FK)
+			foreach ($stationTracks as $t) {
+				$parent = $this->remap($stationMap, Utils::getValueOrNull($t, 'stations_id'));
+				if (is_null($parent)) {
+					$skipped++;
+					continue;
+				}
+				$newId = Uuid::uuid7();
+				$this->ok($this->stationTracksRepo->insertStationTrack(
+					stationTracksId: $newId,
+					stationsId: $parent,
+					owner: $userId,
+					description: (string)(Utils::getValueOrNull($t, 'description') ?? ''),
+					name: (string)Utils::getValueOrNull($t, 'name'),
+					runInLimit: $this->intOrNull(Utils::getValueOrNull($t, 'run_in_limit')),
+					runOutLimit: $this->intOrNull(Utils::getValueOrNull($t, 'run_out_limit')),
+				));
+				$stationTrackMap[(string)Utils::getValueOrNull($t, 'station_tracks_id')] = $newId;
+			}
+
+			// 5. Lines
+			foreach ($lines as $ln) {
+				$newId = Uuid::uuid7();
+				$this->ok($this->lineRepo->insertLine(
+					lineId: $newId,
+					projectsId: $newProjectId,
+					owner: $userId,
+					description: (string)(Utils::getValueOrNull($ln, 'description') ?? ''),
+					name: (string)Utils::getValueOrNull($ln, 'name'),
+				));
+				$lineMap[(string)Utils::getValueOrNull($ln, 'lines_id')] = $newId;
+			}
+
+			// 6. Stations-on-line (leaf — both FKs required)
+			foreach ($stationsOnLine as $sol) {
+				$line = $this->remap($lineMap, Utils::getValueOrNull($sol, 'lines_id'));
+				$station = $this->remap($stationMap, Utils::getValueOrNull($sol, 'project_stations_id'));
+				if (is_null($line) || is_null($station)) {
+					$skipped++;
+					continue;
+				}
+				$this->ok($this->stationsOnLineRepo->insertStationOnLine(
+					stationOnLineId: Uuid::uuid7(),
+					linesId: $line,
+					owner: $userId,
+					projectStationsId: $station,
+					locationM: Utils::floatvalOrNull(Utils::getValueOrNull($sol, 'location_m')) ?? 0.0,
+					locationLonlat: $this->parseStationOnLineLonlat($sol),
+					trackHiddenByDefault: boolval(Utils::getValueOrNull($sol, 'track_hidden_by_default')),
+				));
+			}
+
+			// 7. Stop patterns (line required; from/to stations nullable)
+			foreach ($stopPatterns as $sp) {
+				$line = $this->remap($lineMap, Utils::getValueOrNull($sp, 'lines_id'));
+				if (is_null($line)) {
+					$skipped++;
+					continue;
+				}
+				$newId = Uuid::uuid7();
+				$this->ok($this->stopPatternsRepo->insertStopPattern(
+					stopPatternId: $newId,
+					projectsId: $newProjectId,
+					owner: $userId,
+					name: (string)Utils::getValueOrNull($sp, 'name'),
+					linesId: $line,
+					direction: $this->intOrNull(Utils::getValueOrNull($sp, 'direction')) ?? 1,
+					fromProjectStationsId: $this->remap($stationMap, Utils::getValueOrNull($sp, 'from_project_stations_id')),
+					toProjectStationsId: $this->remap($stationMap, Utils::getValueOrNull($sp, 'to_project_stations_id')),
+				));
+				$stopPatternMap[(string)Utils::getValueOrNull($sp, 'stop_patterns_id')] = $newId;
+			}
+
+			// 8. Stop-pattern rows (leaf — pattern + station required)
+			foreach ($stopPatternRows as $r) {
+				$pattern = $this->remap($stopPatternMap, Utils::getValueOrNull($r, 'stop_patterns_id'));
+				$station = $this->remap($stationMap, Utils::getValueOrNull($r, 'project_stations_id'));
+				if (is_null($pattern) || is_null($station)) {
+					$skipped++;
+					continue;
+				}
+				$this->ok($this->stopPatternRowsRepo->insertStopPatternRow(
+					stopPatternRowId: Uuid::uuid7(),
+					stopPatternsId: $pattern,
+					owner: $userId,
+					projectStationsId: $station,
+					sortKey: $this->intOrNull(Utils::getValueOrNull($r, 'sort_key')) ?? 0,
+					trackName: Utils::getValueOrNull($r, 'track_name'),
+					trackHidden: boolval(Utils::getValueOrNull($r, 'track_hidden')),
+					isOperationOnlyStop: boolval(Utils::getValueOrNull($r, 'is_operation_only_stop')),
+					isPass: boolval(Utils::getValueOrNull($r, 'is_pass')),
+					driveTimeMm: $this->intOrNull(Utils::getValueOrNull($r, 'drive_time_mm')),
+					driveTimeSs: $this->intOrNull(Utils::getValueOrNull($r, 'drive_time_ss')),
+					dwellTimeMm: $this->intOrNull(Utils::getValueOrNull($r, 'dwell_time_mm')),
+					dwellTimeSs: $this->intOrNull(Utils::getValueOrNull($r, 'dwell_time_ss')),
+					showArrive: boolval(Utils::getValueOrNull($r, 'show_arrive') ?? true),
+					showDeparture: boolval(Utils::getValueOrNull($r, 'show_departure') ?? true),
+					arriveStr: Utils::getValueOrNull($r, 'arrive_str'),
+					departureStr: Utils::getValueOrNull($r, 'departure_str'),
+					runInLimit: $this->intOrNull(Utils::getValueOrNull($r, 'run_in_limit')),
+					runOutLimit: $this->intOrNull(Utils::getValueOrNull($r, 'run_out_limit')),
+					remarks: Utils::getValueOrNull($r, 'remarks'),
+					alwaysShowHh: boolval(Utils::getValueOrNull($r, 'always_show_hh')),
+				));
+			}
+
+			// 9. Work groups (attached to the new project)
+			foreach ($workGroups as $wg) {
+				$newId = Uuid::uuid7();
+				$this->ok($this->workGroupsRepo->insertWorkGroup(
+					workGroupId: $newId,
+					projectsId: $newProjectId,
+					owner: $userId,
+					name: (string)Utils::getValueOrNull($wg, 'name'),
+					description: (string)(Utils::getValueOrNull($wg, 'description') ?? ''),
+				));
+				$workGroupMap[(string)Utils::getValueOrNull($wg, 'work_groups_id')] = $newId;
+			}
+
+			// 10. Works (work group required)
+			foreach ($works as $w) {
+				$wg = $this->remap($workGroupMap, Utils::getValueOrNull($w, 'work_groups_id'));
+				if (is_null($wg)) {
+					$skipped++;
+					continue;
+				}
+				$newId = Uuid::uuid7();
+				$this->ok($this->worksRepo->insertWork(
+					worksId: $newId,
+					workGroupsId: $wg,
+					owner: $userId,
+					name: (string)Utils::getValueOrNull($w, 'name'),
+					description: (string)(Utils::getValueOrNull($w, 'description') ?? ''),
+					affectDate: Utils::fromJsonDateOnlyStrToDateTime(Utils::getValueOrNull($w, 'affect_date')),
+					affixContentType: TrvisContentType::fromOrNull(Utils::getValueOrNull($w, 'affix_content_type')),
+					remarks: Utils::getValueOrNull($w, 'remarks'),
+					hasETrainTimetable: boolval(Utils::getValueOrNull($w, 'has_e_train_timetable')),
+					eTrainTimetableContentType: TrvisContentType::fromOrNull(Utils::getValueOrNull($w, 'e_train_timetable_content_type')),
+				));
+				$workMap[(string)Utils::getValueOrNull($w, 'works_id')] = $newId;
+			}
+
+			// 11. Trains (work required)
+			foreach ($trains as $t) {
+				$work = $this->remap($workMap, Utils::getValueOrNull($t, 'works_id'));
+				if (is_null($work)) {
+					$skipped++;
+					continue;
+				}
+				$newId = Uuid::uuid7();
+				$this->ok($this->trainsRepo->insertTrain(
+					trainsId: $newId,
+					worksId: $work,
+					owner: $userId,
+					description: (string)(Utils::getValueOrNull($t, 'description') ?? ''),
+					trainNumber: (string)(Utils::getValueOrNull($t, 'train_number') ?? ''),
+					maxSpeed: Utils::getValueOrNull($t, 'max_speed'),
+					speedType: Utils::getValueOrNull($t, 'speed_type'),
+					nominalTractiveCapacity: Utils::getValueOrNull($t, 'nominal_tractive_capacity'),
+					carCount: $this->intOrNull(Utils::getValueOrNull($t, 'car_count')),
+					destination: Utils::getValueOrNull($t, 'destination'),
+					beginRemarks: Utils::getValueOrNull($t, 'begin_remarks'),
+					afterRemarks: Utils::getValueOrNull($t, 'after_remarks'),
+					remarks: Utils::getValueOrNull($t, 'remarks'),
+					beforeDeparture: Utils::getValueOrNull($t, 'before_departure'),
+					afterArrive: Utils::getValueOrNull($t, 'after_arrive'),
+					trainInfo: Utils::getValueOrNull($t, 'train_info'),
+					direction: $this->intOrNull(Utils::getValueOrNull($t, 'direction')) ?? 1,
+					dayCount: $this->intOrNull(Utils::getValueOrNull($t, 'day_count')) ?? 0,
+					isRideOnMoving: boolval(Utils::getValueOrNull($t, 'is_ride_on_moving')),
+				));
+				$trainMap[(string)Utils::getValueOrNull($t, 'trains_id')] = $newId;
+			}
+
+			// 12. Timetable rows (leaf — train + station required; track/color nullable)
+			foreach ($timetableRows as $r) {
+				$train = $this->remap($trainMap, Utils::getValueOrNull($r, 'trains_id'));
+				$station = $this->remap($stationMap, Utils::getValueOrNull($r, 'stations_id'));
+				if (is_null($train) || is_null($station)) {
+					$skipped++;
+					continue;
+				}
+				$this->ok($this->timetableRowsRepo->insertTimetableRow(
+					timetableRowsId: Uuid::uuid7(),
+					trainsId: $train,
+					owner: $userId,
+					stationsId: $station,
+					stationTracksId: $this->remap($stationTrackMap, Utils::getValueOrNull($r, 'station_tracks_id')),
+					colorsIdMarker: $this->remap($colorMap, Utils::getValueOrNull($r, 'colors_id_marker')),
+					description: (string)(Utils::getValueOrNull($r, 'description') ?? ''),
+					driveTimeMm: $this->intOrNull(Utils::getValueOrNull($r, 'drive_time_mm')),
+					driveTimeSs: $this->intOrNull(Utils::getValueOrNull($r, 'drive_time_ss')),
+					isOperationOnlyStop: boolval(Utils::getValueOrNull($r, 'is_operation_only_stop')),
+					isPass: boolval(Utils::getValueOrNull($r, 'is_pass')),
+					hasBracket: boolval(Utils::getValueOrNull($r, 'has_bracket')),
+					isLastStop: boolval(Utils::getValueOrNull($r, 'is_last_stop')),
+					arriveTimeHh: $this->intOrNull(Utils::getValueOrNull($r, 'arrive_time_hh')),
+					arriveTimeMm: $this->intOrNull(Utils::getValueOrNull($r, 'arrive_time_mm')),
+					arriveTimeSs: $this->intOrNull(Utils::getValueOrNull($r, 'arrive_time_ss')),
+					departureTimeHh: $this->intOrNull(Utils::getValueOrNull($r, 'departure_time_hh')),
+					departureTimeMm: $this->intOrNull(Utils::getValueOrNull($r, 'departure_time_mm')),
+					departureTimeSs: $this->intOrNull(Utils::getValueOrNull($r, 'departure_time_ss')),
+					runInLimit: $this->intOrNull(Utils::getValueOrNull($r, 'run_in_limit')),
+					runOutLimit: $this->intOrNull(Utils::getValueOrNull($r, 'run_out_limit')),
+					remarks: Utils::getValueOrNull($r, 'remarks'),
+					arriveStr: Utils::getValueOrNull($r, 'arrive_str'),
+					departureStr: Utils::getValueOrNull($r, 'departure_str'),
+					markerText: Utils::getValueOrNull($r, 'marker_text'),
+					workType: WorkAtStationType::fromOrNull(Utils::getValueOrNull($r, 'work_type')),
+				));
+			}
+
+			$selectResult = $this->projectsRepo->selectProjectOne($userId, $newProjectId);
+			if ($selectResult->isError) {
+				$this->db->rollBack();
+				return $selectResult;
+			}
+
+			$this->db->commit();
+			if ($skipped > 0) {
+				$this->logger->warning(
+					"import: {skipped} row(s) skipped (dangling required FK to a soft-deleted parent)",
+					['skipped' => $skipped],
+				);
+			}
+			return RetValueOrError::withValue($selectResult->value, Constants::HTTP_CREATED);
+		} catch (ImportInsertException $e) {
+			if ($this->db->inTransaction()) {
+				$this->db->rollBack();
+			}
+			$this->logger->warning("import insert failed: {msg}", ['msg' => $e->getMessage()]);
+			return RetValueOrError::withError($e->statusCode, $e->getMessage());
+		} catch (\Throwable $e) {
+			if ($this->db->inTransaction()) {
+				$this->db->rollBack();
+			}
+			$this->logger->error("import failed: {exception}", ['exception' => $e]);
+			return RetValueOrError::withError(Constants::HTTP_INTERNAL_SERVER_ERROR, 'import failed');
+		}
+	}
+
+	/** Throw on a failed insert so the whole import transaction rolls back. */
+	private function ok(RetValueOrError $r): void
+	{
+		if ($r->isError) {
+			throw new ImportInsertException($r->statusCode, $r->errorMsg);
+		}
+	}
+
+	/**
+	 * Read an array property from the parsed body, tolerating object/array and
+	 * a missing/null key (→ []).
+	 *
+	 * @param array<string,mixed>|object $graph
+	 * @return array<mixed>
+	 */
+	private function listOf(mixed $graph, string $key): array
+	{
+		$v = Utils::getValueOrNull($graph, $key);
+		return is_array($v) ? array_values($v) : [];
+	}
+
+	/** old-id string → remapped new UuidInterface, or null if absent/unmapped. */
+	private function remap(array $map, mixed $oldId): ?UuidInterface
+	{
+		if (is_null($oldId)) {
+			return null;
+		}
+		$key = (string)$oldId;
+		return $map[$key] ?? null;
+	}
+
+	private function intOrNull(mixed $v): ?int
+	{
+		return is_null($v) ? null : intval($v);
+	}
+
+	/** array → stdClass (for `->prop` access); object/null pass through. */
+	private function toObjOrNull(mixed $v): ?object
+	{
+		if (is_null($v)) {
+			return null;
+		}
+		return is_array($v) ? (object)$v : $v;
+	}
+
+	private function parseStationLonlat(mixed $item): ?StationLocationLonlat
+	{
+		$raw = Utils::getValueOrNull($item, 'location_lonlat');
+		if (is_null($raw)) {
+			return null;
+		}
+		$ll = new StationLocationLonlat();
+		$ll->setData([
+			'longitude' => Utils::floatvalOrNull(Utils::getValueOrNull($raw, 'longitude')),
+			'latitude' => Utils::floatvalOrNull(Utils::getValueOrNull($raw, 'latitude')),
+		]);
+		return $ll;
+	}
+
+	private function parseStationOnLineLonlat(mixed $item): ?StationOnLineLocationLonlat
+	{
+		$raw = Utils::getValueOrNull($item, 'location_lonlat');
+		if (is_null($raw)) {
+			return null;
+		}
+		$ll = new StationOnLineLocationLonlat();
+		$ll->setData([
+			'longitude' => Utils::floatvalOrNull(Utils::getValueOrNull($raw, 'longitude')),
+			'latitude' => Utils::floatvalOrNull(Utils::getValueOrNull($raw, 'latitude')),
+		]);
+		return $ll;
+	}
+}
+
+/** Internal: an insert returned an error; carries the status for the response. */
+final class ImportInsertException extends \RuntimeException
+{
+	public function __construct(public readonly int $statusCode, string $message)
+	{
+		parent::__construct($message);
+	}
+}
+
+/** Internal: export hit the per-entity row cap. */
+final class TransferTooLargeException extends \RuntimeException
+{
+}

--- a/backend/src/trvis_backend/service/StopPatternsService.php
+++ b/backend/src/trvis_backend/service/StopPatternsService.php
@@ -32,6 +32,22 @@ final class StopPatternsService
 		$this->projectsPrivilegesRepo = new ProjectsPrivilegesRepo($db, $logger);
 	}
 
+	/** Coerce a request value (string UUID, or UuidInterface from a direct
+	 *  test caller) into a UuidInterface. */
+	private static function asUuid(mixed $v): UuidInterface
+	{
+		return $v instanceof UuidInterface ? $v : Uuid::fromString((string)$v);
+	}
+
+	/** Like asUuid() but passes null/empty through as null. */
+	private static function asUuidOrNull(mixed $v): ?UuidInterface
+	{
+		if ($v === null || $v === '') {
+			return null;
+		}
+		return self::asUuid($v);
+	}
+
 	/**
 	 * @return RetValueOrError<StopPattern>
 	 */
@@ -140,10 +156,14 @@ final class StopPatternsService
 					projectsId: $projectsId,
 					owner: $userId,
 					name: $d->name,
-					linesId: $d->lines_id,
+					// The HTTP path delivers these as strings (parsed JSON body);
+					// direct-service test callers pass UuidInterface already.
+					// The repo demands UuidInterface, so coerce strings here —
+					// without this, createStopPattern is a hard 500 (TypeError).
+					linesId: self::asUuid($d->lines_id),
 					direction: $d->direction ?? 1,
-					fromProjectStationsId: $d->from_project_stations_id,
-					toProjectStationsId: $d->to_project_stations_id,
+					fromProjectStationsId: self::asUuidOrNull($d->from_project_stations_id),
+					toProjectStationsId: self::asUuidOrNull($d->to_project_stations_id),
 				);
 				if ($insertResult->isError) {
 					$this->db->rollBack();

--- a/backend/src/trvis_backend/service/WorksService.php
+++ b/backend/src/trvis_backend/service/WorksService.php
@@ -142,7 +142,13 @@ final class WorksService
 					owner: $userId,
 					name: $d->name,
 					description: $d->description,
-					affectDate: $d->affect_date,
+					// HTTP path delivers affect_date as a string (parsed JSON);
+					// direct-service test callers pass a DateTimeInterface. The
+					// repo demands ?DateTimeInterface, so coerce strings here —
+					// without this, creating a Work with any date is a hard 500.
+					affectDate: $d->affect_date instanceof \DateTimeInterface
+						? $d->affect_date
+						: Utils::fromJsonDateOnlyStrToDateTime($d->affect_date),
 					affixContentType: $d->affix_content_type,
 					remarks: $d->remarks,
 					hasETrainTimetable: $d->has_e_train_timetable ?? false,
@@ -243,7 +249,11 @@ final class WorksService
 			hasName: $hasName,
 			description: $hasDescription ? $body->description : null,
 			hasDescription: $hasDescription,
-			affectDate: $hasAffectDate ? $body->affect_date : null,
+			affectDate: $hasAffectDate
+				? ($body->affect_date instanceof \DateTimeInterface
+					? $body->affect_date
+					: Utils::fromJsonDateOnlyStrToDateTime($body->affect_date))
+				: null,
 			hasAffectDate: $hasAffectDate,
 			affixContentType: $hasAffixContentType ? $body->affix_content_type : null,
 			hasAffixContentType: $hasAffixContentType,

--- a/backend/src/trvis_backend/validator/RequestValidator.php
+++ b/backend/src/trvis_backend/validator/RequestValidator.php
@@ -58,6 +58,12 @@ final class RequestValidator
 				if ($validateResult->isError) {
 					return $validateResult;
 				}
+				// $item is a foreach copy; the rules above mutate it by reference
+				// (e.g. normalizing color_8bit / lonlat arrays into value objects).
+				// Without writing the copy back, those conversions are lost and the
+				// downstream model carries the raw array — surfacing as a NOT NULL /
+				// type error at insert time. Propagate the normalized element.
+				$d[$i] = $item;
 			}
 			return RetValueOrError::withValue(null);
 		}

--- a/backend/tests/Api/ProjectTransferServiceTest.php
+++ b/backend/tests/Api/ProjectTransferServiceTest.php
@@ -1,0 +1,275 @@
+<?php
+
+/**
+ * TRViS用 時刻表管理用API
+ *
+ * DB integration round-trip for the dedicated export/import endpoints
+ * (ProjectTransferService). This is the real correctness gate for the
+ * server-side id remap: seed a rich graph → export → import → re-export →
+ * assert per-entity count equality. A remap bug (a dropped child create from a
+ * dangling FK, a mis-wired parent) shrinks a count and fails here in seconds,
+ * under the same strict+native-prepares harness as the rest of the suite.
+ *
+ * The export value is JSON-encoded then decoded to assoc arrays before import,
+ * exactly mirroring the HTTP wire (BaseModel magic props are invisible to
+ * property_exists, so passing raw models would not exercise the real path).
+ *
+ * @see tests/Integration/IntegrationTestCase.php
+ */
+
+namespace dev_t0r\trvis_backend\service;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use dev_t0r\trvis_backend\model\Color;
+use dev_t0r\trvis_backend\model\Station;
+use dev_t0r\trvis_backend\model\StationOnLine;
+use dev_t0r\trvis_backend\model\StationRecordType;
+use dev_t0r\trvis_backend\model\StopPattern;
+use dev_t0r\trvis_backend\model\StopPatternRow;
+use dev_t0r\trvis_backend\model\TimetableRow;
+use dev_t0r\trvis_backend\model\Train;
+use dev_t0r\trvis_backend\model\Work;
+use dev_t0r\trvis_backend\repo\WorkGroupsRepo;
+use dev_t0r\trvis_backend\tests\integration\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+#[CoversClass(\dev_t0r\trvis_backend\service\ProjectTransferService::class)]
+class ProjectTransferServiceTest extends IntegrationTestCase
+{
+	private ?string $importedProjectId = null;
+
+	private function transfer(): ProjectTransferService
+	{
+		return new ProjectTransferService($this->db, $this->logger);
+	}
+
+	/** Direct PDO insert of a project_lines row (LineService::create has a scalar sig). */
+	private function newLine(string $name = 'L'): UuidInterface
+	{
+		$id = Uuid::uuid7();
+		$this->db->prepare(
+			"INSERT INTO project_lines (project_lines_id, projects_id, description, owner, name)"
+			. " VALUES (:id, :pid, '', :owner, :name)"
+		)->execute([
+			':id' => $id->getBytes(),
+			':pid' => $this->projectId->getBytes(),
+			':owner' => $this->userId,
+			':name' => $name,
+		]);
+		$this->register('project_lines', 'project_lines_id', (string)$id);
+		return $id;
+	}
+
+	/** Seed a non-trivial graph under the fixture project; returns expected counts. */
+	private function seedGraph(): array
+	{
+		$pid = $this->projectId;
+		$uid = $this->userId;
+
+		// Colors
+		$colorSvc = new ColorsService($this->db, $this->logger);
+		// color_real columns are NOT NULL in the schema, so every color must carry it.
+		$cr = $colorSvc->create($pid, $uid, [
+			$this->makeModel(Color::class, ['name' => 'C1', 'description' => '', 'color_8bit' => (object)['red' => 10, 'green' => 20, 'blue' => 30], 'color_real' => (object)['red' => 0.1, 'green' => 0.2, 'blue' => 0.3]]),
+			$this->makeModel(Color::class, ['name' => 'C2', 'description' => '', 'color_8bit' => (object)['red' => 40, 'green' => 50, 'blue' => 60], 'color_real' => (object)['red' => 0.4, 'green' => 0.5, 'blue' => 0.6]]),
+		]);
+		$this->assertOk($cr, 'seed colors');
+		$color1 = $cr->value[0]->colors_id;
+		foreach ($cr->value as $c) {
+			$this->register('colors', 'colors_id', (string)$c->colors_id);
+		}
+
+		// Stations
+		$stationSvc = new StationsService($this->db, $this->logger);
+		$stationIds = [];
+		foreach (['S1', 'S2'] as $name) {
+			$r = $stationSvc->createStation(
+				projectsId: $pid,
+				userId: $uid,
+				name: $name,
+				fullName: null,
+				locationKm: 0.0,
+				locationLonlat: null,
+				onStationDetectRadiusM: null,
+				recordType: StationRecordType::normal,
+				alwaysShowHh: false,
+			);
+			$this->assertOk($r, "seed station $name");
+			$stationIds[] = $r->value->stations_id;
+			$this->register('stations', 'stations_id', (string)$r->value->stations_id);
+		}
+
+		// Station track on station 1
+		$trackSvc = new StationTracksService($this->db, $this->logger);
+		$tr = $trackSvc->create($stationIds[0], $uid, [
+			$this->makeModel(\dev_t0r\trvis_backend\model\StationTrack::class, ['name' => 'T1', 'description' => '']),
+		]);
+		$this->assertOk($tr, 'seed station track');
+		$this->register('station_tracks', 'station_tracks_id', (string)$tr->value[0]->station_tracks_id);
+
+		// Line + stations-on-line
+		$line1 = $this->newLine();
+		$solSvc = new StationsOnLineService($this->db, $this->logger);
+		$sol = $solSvc->create($line1, $uid, [
+			$this->makeModel(StationOnLine::class, ['project_stations_id' => $stationIds[0], 'location_m' => 0.0, 'track_hidden_by_default' => false]),
+			$this->makeModel(StationOnLine::class, ['project_stations_id' => $stationIds[1], 'location_m' => 1000.0, 'track_hidden_by_default' => false]),
+		]);
+		$this->assertOk($sol, 'seed stations_on_line');
+		foreach ($sol->value as $s) {
+			$this->register('stations_on_line', 'stations_on_line_id', (string)$s->stations_on_line_id);
+		}
+
+		// Stop pattern + rows
+		$spSvc = new StopPatternsService($this->db, $this->logger);
+		$spr = $spSvc->create($pid, $uid, [
+			$this->makeModel(StopPattern::class, ['name' => 'SP1', 'lines_id' => $line1, 'direction' => 1]),
+		]);
+		$this->assertOk($spr, 'seed stop_pattern');
+		$sp1 = $spr->value[0]->stop_patterns_id;
+		$this->register('stop_patterns', 'stop_patterns_id', (string)$sp1);
+
+		$rowSvc = new StopPatternRowsService($this->db, $this->logger);
+		$rr = $rowSvc->create($sp1, $uid, [
+			$this->makeModel(StopPatternRow::class, ['project_stations_id' => $stationIds[0], 'sort_key' => 0]),
+			$this->makeModel(StopPatternRow::class, ['project_stations_id' => $stationIds[1], 'sort_key' => 1]),
+		]);
+		$this->assertOk($rr, 'seed stop_pattern_rows');
+		foreach ($rr->value as $r) {
+			$this->register('stop_pattern_rows', 'stop_pattern_rows_id', (string)$r->stop_pattern_rows_id);
+		}
+
+		// Work group → work → train → timetable rows
+		$wgSvc = new WorkGroupsService($this->db, $this->logger);
+		$wg = $wgSvc->createWorkGroupInProject($pid, $uid, '', 'WG1');
+		$this->assertOk($wg, 'seed work_group');
+		$wg1 = $wg->value->work_groups_id;
+		$this->register('work_groups', 'work_groups_id', (string)$wg1);
+
+		$workSvc = new WorksService($this->db, $this->logger);
+		$wk = $workSvc->create($wg1, $uid, [
+			$this->makeModel(Work::class, ['name' => 'WK1', 'description' => '']),
+		]);
+		$this->assertOk($wk, 'seed work');
+		$wk1 = $wk->value[0]->works_id;
+		$this->register('works', 'works_id', (string)$wk1);
+
+		$trainSvc = new TrainsService($this->db, $this->logger);
+		$tn = $trainSvc->create($wk1, $uid, [
+			$this->makeModel(Train::class, ['train_number' => '1M', 'description' => '', 'direction' => 1, 'day_count' => 0]),
+		]);
+		$this->assertOk($tn, 'seed train');
+		$train1 = $tn->value[0]->trains_id;
+		$this->register('trains', 'trains_id', (string)$train1);
+
+		$ttSvc = new TimetableRowsService($this->db, $this->logger);
+		$tt = $ttSvc->create($train1, $uid, [
+			$this->makeModel(TimetableRow::class, ['stations_id' => $stationIds[0], 'colors_id_marker' => $color1, 'description' => '', 'drive_time_mm' => 2, 'drive_time_ss' => 0]),
+			$this->makeModel(TimetableRow::class, ['stations_id' => $stationIds[1], 'description' => '', 'drive_time_mm' => 3, 'drive_time_ss' => 0]),
+		]);
+		$this->assertOk($tt, 'seed timetable_rows');
+		foreach ($tt->value as $r) {
+			$this->register('timetable_rows', 'timetable_rows_id', (string)$r->timetable_rows_id);
+		}
+
+		return [
+			'colors' => 2,
+			'stations' => 2,
+			'station_tracks' => 1,
+			'lines' => 1,
+			'stations_on_line' => 2,
+			'stop_patterns' => 1,
+			'stop_pattern_rows' => 2,
+			'work_groups' => 1,
+			'works' => 1,
+			'trains' => 1,
+			'timetable_rows' => 2,
+		];
+	}
+
+	/** Per-entity counts from an export value (the flat ProjectGraph arrays). */
+	private function countsOf(array $graph): array
+	{
+		$out = [];
+		foreach (['colors', 'stations', 'station_tracks', 'lines', 'stations_on_line',
+			'stop_patterns', 'stop_pattern_rows', 'work_groups', 'works', 'trains', 'timetable_rows'] as $k) {
+			$out[$k] = count($graph[$k] ?? []);
+		}
+		return $out;
+	}
+
+	public function testExportImportRoundTripReproducesGraph(): void
+	{
+		$expected = $this->seedGraph();
+
+		// Export the seeded project.
+		$exportResult = $this->transfer()->export($this->projectId, $this->userId);
+		$this->assertOk($exportResult, 'export');
+		$sourceGraph = $exportResult->value;
+		$this->assertSame($expected, $this->countsOf($sourceGraph), 'exported counts match seed');
+
+		// Wire round-trip: encode→decode to assoc arrays (what the HTTP body is).
+		$wire = json_decode(json_encode($sourceGraph), true);
+		$this->assertIsArray($wire, 'graph serializes');
+
+		// Import into a brand-new project.
+		$importResult = $this->transfer()->import($this->userId, $wire);
+		$this->assertOk($importResult, 'import');
+		$newProjectId = (string)$importResult->value->projects_id;
+		$this->assertNotSame((string)$this->projectId, $newProjectId, 'import creates a new project');
+		$this->importedProjectId = $newProjectId;
+
+		// The new project must be owner-visible (catches a missing admin-privilege row).
+		$visible = (new \dev_t0r\trvis_backend\service\ProjectsService($this->db, $this->logger))
+			->selectProjectOne(Uuid::fromString($newProjectId), $this->userId);
+		$this->assertOk($visible, 'imported project owner-visible');
+
+		// Its work groups must be owner-visible too (new-style WG delegates to project).
+		$wgVisible = (new WorkGroupsRepo($this->db, $this->logger))
+			->selectWorkGroupPageByProjectId(Uuid::fromString($newProjectId), $this->userId, 1, 50, null);
+		$this->assertOk($wgVisible, 'imported work_groups visible');
+		$this->assertCount(1, $wgVisible->value, 'imported work_group count');
+
+		// Re-export the imported project; every count must match the source.
+		$reExport = $this->transfer()->export(Uuid::fromString($newProjectId), $this->userId);
+		$this->assertOk($reExport, 're-export');
+		$this->assertSame(
+			$this->countsOf($sourceGraph),
+			$this->countsOf($reExport->value),
+			'imported graph reproduces every entity count',
+		);
+	}
+
+	protected function tearDown(): void
+	{
+		// Hard-delete the imported project's whole graph (its rows were created
+		// server-side with fresh ids, so they aren't individually registered).
+		if ($this->importedProjectId !== null) {
+			$pid = Uuid::fromString($this->importedProjectId)->getBytes();
+			$cascades = [
+				"DELETE FROM timetable_rows WHERE trains_id IN (SELECT trains_id FROM trains WHERE works_id IN (SELECT works_id FROM works WHERE work_groups_id IN (SELECT work_groups_id FROM work_groups WHERE projects_id = :pid)))",
+				"DELETE FROM trains WHERE works_id IN (SELECT works_id FROM works WHERE work_groups_id IN (SELECT work_groups_id FROM work_groups WHERE projects_id = :pid))",
+				"DELETE FROM works WHERE work_groups_id IN (SELECT work_groups_id FROM work_groups WHERE projects_id = :pid)",
+				"DELETE FROM work_groups WHERE projects_id = :pid",
+				"DELETE FROM stop_pattern_rows WHERE projects_id = :pid",
+				"DELETE FROM stop_patterns WHERE projects_id = :pid",
+				"DELETE FROM stations_on_line WHERE projects_id = :pid",
+				"DELETE FROM station_tracks WHERE stations_id IN (SELECT stations_id FROM stations WHERE projects_id = :pid)",
+				"DELETE FROM project_lines WHERE projects_id = :pid",
+				"DELETE FROM stations WHERE projects_id = :pid",
+				"DELETE FROM colors WHERE projects_id = :pid",
+				"DELETE FROM projects_privileges WHERE projects_id = :pid",
+				"DELETE FROM projects WHERE projects_id = :pid",
+			];
+			foreach ($cascades as $sql) {
+				try {
+					$this->db->prepare($sql)->execute([':pid' => $pid]);
+				} catch (\Throwable $e) {
+					// best-effort
+				}
+			}
+			$this->importedProjectId = null;
+		}
+		parent::tearDown();
+	}
+}

--- a/backend/tests/Integration/IntegrationTestCase.php
+++ b/backend/tests/Integration/IntegrationTestCase.php
@@ -50,6 +50,11 @@ abstract class IntegrationTestCase extends TestCase
 				// FOUND_ROWS; AUTOCOMMIT=false is prod-only and orthogonal to
 				// H7, so it is intentionally not set here.)
 				PDO::MYSQL_ATTR_FOUND_ROWS => true,
+				// Mirror dev/prod (config.docker.inc.php) which runs native
+				// prepares. Without this the harness defaults to emulated
+				// prepares and silently tolerates reused named placeholders
+				// (HY093) that break the real app — exactly the §0-3 drift.
+				PDO::ATTR_EMULATE_PREPARES => false,
 			]);
 		} catch (\PDOException $e) {
 			self::$skipReason = 'Test DB unavailable (' . $e->getMessage() . ')';

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -19,7 +19,9 @@
 		"packages/",
 		"dist/",
 		"vite.config.ts",
-		"i18next-parser.config.ts"
+		"i18next-parser.config.ts",
+		"playwright.config.ts",
+		"e2e/"
 	],
 	"parser": "@typescript-eslint/parser",
 	"parserOptions": {

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -26,6 +26,12 @@ dist-ssr
 !.yarn/versions
 .pnp.*
 
+# Playwright E2E artifacts (reports, traces, screenshots, videos)
+/test-results/
+/e2e-report/
+/playwright-report/
+/.playwright/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/e2e/AGENT_BRIEF.md
+++ b/frontend/e2e/AGENT_BRIEF.md
@@ -1,0 +1,94 @@
+# E2E spec-writing brief (shared)
+
+You are writing Playwright E2E specs for the TRViS Timetable editor frontend.
+Goal: **click every button / button-like control on your assigned screen and
+assert the REAL EFFECT**, then report which controls are unimplemented,
+wired-to-the-wrong-source, or hit a backend 500.
+
+## The whole point
+
+The user is hunting for controls that *look* like they work but don't —
+buttons, and **button-like `onClick` divs/spans, context-menu items, kebab
+menus, drag-reorder handles**. A test that only checks "a modal opened" or "a
+click happened" PASSES on exactly these broken controls and is useless. **Every
+spec must assert the downstream effect**, and for create/edit/delete the gold
+standard is: **reload the page and assert via the rendered (API-backed) list.**
+The app renders from the backend API (TanStack Query), NOT from any in-memory
+sample data — so a reload is what proves a mutation actually persisted.
+
+## Harness (already built — use it, don't reinvent)
+
+- `import { test, expect } from "./fixtures";` — `test` has an `appPage`
+  fixture: a Page already signed in (Firebase emulator) and on the project
+  list. Use `test("...", async ({ appPage: page }) => { ... })`.
+- `import { login } from "./fixtures";` for manual control if needed.
+- `import { createProject, openProject, gotoLines, gotoColors,
+  createWorkGroup, createWork, uniqueName, modal, clickModalButton,
+  projectCard } from "./helpers";` — shared nav/creation helpers. Read
+  `e2e/helpers.ts` to see exactly what they do.
+- Default app language is **Japanese** (`ja`). All visible labels are the
+  Japanese strings in `src/i18n/strings.ts`. Use **regex / substring** role
+  matching, never exact — labels carry emoji + whitespace (e.g. "📥 インポート").
+
+## Hard rules
+
+1. **Do NOT edit anything under `src/`** and **do NOT edit `e2e/helpers.ts`,
+   `e2e/fixtures.ts`, `e2e/credentials.ts`, `playwright.config.ts`, or
+   `global-setup.ts`.** You may only CREATE your own spec file. Put any
+   screen-specific helpers as local functions inside your spec file.
+2. **Self-seed** every test with `uniqueName("...")`. Never depend on
+   pre-existing data.
+3. **Scope every assertion to your own uniquely-named entities.** NEVER assert
+   global counts ("N 件"), "list length equals", or anything about entities you
+   didn't create — other specs run concurrently against the same backend.
+4. Capture dialogs so they don't hang the run AND so you can report errors:
+   ```ts
+   const alerts: string[] = [];
+   page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+   ```
+   Mutations surface backend errors via `alert(e.message)` (an `ApiError`
+   message). If a button "does nothing", check `alerts` — an alert with a 4xx/5xx
+   message means backend-broken, not frontend-unimplemented. Note: native
+   `confirm()` is used by JSON import; entity deletes use a custom modal
+   (`.modal` with a 削除 button), NOT native confirm.
+5. Run ONLY your own spec, with your own output dir:
+   `yarn playwright test e2e/<yourfile>.spec.ts --reporter=line --output=test-results/<yourscreen>`
+   Iterate until selectors are stable and each test's pass/fail reflects the
+   real app behavior (a red test because the FEATURE is broken is a SUCCESS for
+   this exercise — keep it red and document it; a red test because your SELECTOR
+   is wrong must be fixed).
+6. For a control you believe is broken, write the spec to assert the
+   *correct* behavior (so it fails now and will pass once fixed), and mark it
+   `test.fail()` ONLY if you want green CI — but prefer leaving it as a normal
+   failing assertion and documenting it. Either way, the assertion must encode
+   the intended effect.
+
+## Triage buckets for your report
+
+For each control, classify:
+- **OK** — works, effect verified (ideally across reload).
+- **UNIMPLEMENTED** — handler missing / no-op; nothing happens, no network call.
+- **WRONG-SOURCE** — does something but against the wrong data (e.g. reads/writes
+  in-memory sample data instead of the API), so the visible effect is missing or
+  stale.
+- **BACKEND-500** — frontend calls the API correctly but the server errors
+  (alert shows a 4xx/5xx). Include the status/message.
+- **UNSURE** — couldn't determine; explain what blocked you.
+
+## Report format (return this as your final message)
+
+```
+## <Screen name>
+Spec file: e2e/<file>.spec.ts  (N tests: P passed, F failed)
+
+### Clickable inventory
+- <control> → <handler/expected effect> → <bucket> — <evidence: alert text,
+  HTTP status, persisted? reload-checked?>
+...
+
+### Findings (non-OK only), most severe first
+1. [BUCKET] <control>: <what's wrong> — <evidence> — <file:line of the handler
+   in src, if you found it>
+```
+
+Keep evidence concrete (HTTP status, alert text, "created then reload → gone").

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -1,0 +1,57 @@
+# E2E (Playwright)
+
+全画面のボタン／ボタン的コントロールを「効果まで」検証する E2E スイート。
+クリックで終わらず、作成/編集/削除は **リロード後に API 由来の描画で永続を確認**する
+（メモリ上サンプルではなく実 API に反映されたかを見る）。
+
+## 前提・起動
+
+```sh
+# 1) バックエンドスタック（API + MySQL + Firebase Auth Emulator）
+docker compose up -d php mysql firebase
+
+# 2) 初回のみ: 開発設定を実体化（README ルート手順と同じ）
+cp backend/config/prod/config.docker.inc.php backend/config/prod/config.inc.php
+
+# 3) E2E 実行（vite dev は playwright が自動起動/再利用）
+cd frontend
+yarn playwright test                 # 全件
+yarn playwright test e2e/projects.spec.ts   # 個別
+yarn playwright test --ui            # UI モード
+```
+
+- vite dev(`:5173`) は `/api` を `:8080`(php) へプロキシ。`localhost` 判定で
+  Firebase は Auth Emulator(`:9099`) に接続。
+- `global-setup.ts` が E2E ユーザ（`e2e-user@example.com` / `Passw0rd!` ほか）を
+  emulator に冪等プロビジョニング。シード `0000` はフォームのパスワード規則を満たさず
+  UI ログインできないため、規則を満たすユーザを別途用意している。
+
+## 構成
+
+- `fixtures.ts` … `test`(`appPage`=ログイン済みページ) と `login()`。
+- `helpers.ts` … プロジェクト/WG/ワーク作成・画面遷移・`uniqueName()` など共有ヘルパー。
+- `credentials.ts` / `global-setup.ts` … 認証ユーザ。
+- `AGENT_BRIEF.md` … スペック作成方針（効果アサート徹底、サンプル `data` 罠 等）。
+- `*.spec.ts` … 画面別スペック。
+
+## 前提（重要・未決のオーナー判断）
+
+作成系 API を通すには、**現状このマシン限定**の回避策が要る（追跡対象外のため
+クリーンチェックアウト＋新規 DB ボリュームでは createProject が 500 になり全滅する）:
+
+- MySQL `sql_mode` から `ONLY_FULL_GROUP_BY` を除外（実行中コンテナに `SET PERSIST`）。
+- `config.inc.php` で `ATTR_EMULATE_PREPARES => true`（同名プレースホルダ再利用対策）。
+- レート制限の緩和（同 `config.inc.php`）。
+
+これらを追跡ファイルにコミットするか、クエリを正規修正するかは未決。詳細・推奨は
+[`UNIMPLEMENTED.md` §0](../../UNIMPLEMENTED.md) の「最重要・オーナー判断」を参照。
+
+## 注意
+
+- 各テストは `uniqueName()` で自己シードし、**自分が作った実体のみ**を検証する
+  （件数や他テストの実体には依存しない）。バックエンド DB は共有で、`workers:1` 直列。
+- カバレッジは **部分的**（4/7 画面、うち work/timetable は一部赤）。ColorManager・
+  StopPatternWizard 内部・AppShell（テーマ/言語）・認証ダイアログ群は**未走査**。
+- 既知の未完: `work` / `timetable` の一部はセレクタ/リロード後ナビのスペック債務で赤
+  （製品バグではない。work 作成の永続は DB で確認済み）。詳細と製品側の所見は
+  リポジトリルート [`UNIMPLEMENTED.md`](../../UNIMPLEMENTED.md) を参照。

--- a/frontend/e2e/_harness-check.spec.ts
+++ b/frontend/e2e/_harness-check.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "./fixtures";
+import { createProject, projectCard, uniqueName } from "./helpers";
+
+// Validates the shared harness: create persists across reload (the
+// effect-assertion pattern the real specs must follow).
+test("created project persists across reload", async ({ appPage: page }) => {
+	const name = uniqueName("harness-proj");
+	await createProject(page, name);
+	await page.reload();
+	await expect(projectCard(page, name)).toBeVisible({ timeout: 10_000 });
+});

--- a/frontend/e2e/credentials.ts
+++ b/frontend/e2e/credentials.ts
@@ -1,0 +1,8 @@
+// Shared E2E credentials. The password satisfies the sign-in form's validation
+// (length 8-32, >=1 upper/lower/digit/symbol, ASCII printable, no space).
+export const E2E_EMAIL = "e2e-user@example.com";
+export const E2E_PASSWORD = "Passw0rd!";
+
+// A second user, for cross-user / privilege tests.
+export const E2E_EMAIL_2 = "e2e-user2@example.com";
+export const E2E_PASSWORD_2 = "Passw0rd!";

--- a/frontend/e2e/export-import.spec.ts
+++ b/frontend/e2e/export-import.spec.ts
@@ -1,0 +1,199 @@
+// Round-trip proof for the live-API export/import (replaces the old in-memory
+// sample-data export). Seeds a rich graph via the API, exports it through the
+// real UI, imports the downloaded file through the real UI, then verifies via
+// the API that the imported project reproduces every entity count — which can
+// only hold if the whole graph walk + foreign-key remap is correct (a dangling
+// FK would drop a child create and shrink a count).
+import { test, expect, type APIRequestContext } from "@playwright/test";
+
+import { test as appTest } from "./fixtures";
+import { E2E_EMAIL, E2E_PASSWORD } from "./credentials";
+import { uniqueName } from "./helpers";
+
+const API = "http://localhost:8080/api/v1";
+const EMU =
+	"http://localhost:9099/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=dummy";
+
+async function idToken(request: APIRequestContext): Promise<string> {
+	const r = await request.post(EMU, {
+		data: { email: E2E_EMAIL, password: E2E_PASSWORD, returnSecureToken: true },
+	});
+	return (await r.json()).idToken as string;
+}
+
+function api(request: APIRequestContext, tok: string) {
+	const h = { Authorization: `Bearer ${tok}`, "Content-Type": "application/json" };
+	return {
+		async post(path: string, body: unknown): Promise<any> {
+			const r = await request.post(`${API}${path}`, { headers: h, data: body });
+			if (r.status() >= 300) {
+				throw new Error(`POST ${path} -> ${r.status()} ${await r.text()}`);
+			}
+			const j = await r.json();
+			return Array.isArray(j) ? j[0] : j;
+		},
+		async list(path: string): Promise<any[]> {
+			const r = await request.get(`${API}${path}?p=1&limit=100`, { headers: h });
+			if (r.status() >= 300) {
+				throw new Error(`GET ${path} -> ${r.status()} ${await r.text()}`);
+			}
+			const j = await r.json();
+			return Array.isArray(j) ? j : [];
+		},
+	};
+}
+
+// Count every entity in a project's graph via the API.
+async function countGraph(
+	request: APIRequestContext,
+	tok: string,
+	pid: string
+): Promise<Record<string, number>> {
+	const a = api(request, tok);
+	const [lines, stations, colors, stopPatterns, workGroups] = await Promise.all([
+		a.list(`/projects/${pid}/lines`),
+		a.list(`/projects/${pid}/stations`),
+		a.list(`/projects/${pid}/colors`),
+		a.list(`/projects/${pid}/stop_patterns`),
+		a.list(`/projects/${pid}/work_groups`),
+	]);
+	let stationsOnLine = 0;
+	for (const l of lines) {
+		stationsOnLine += (await a.list(`/lines/${l.lines_id}/stations_on_line`)).length;
+	}
+	let stopPatternRows = 0;
+	for (const sp of stopPatterns) {
+		stopPatternRows += (await a.list(`/stop_patterns/${sp.stop_patterns_id}/rows`)).length;
+	}
+	let works = 0;
+	let trains = 0;
+	let timetableRows = 0;
+	for (const wg of workGroups) {
+		const ws = await a.list(`/work_groups/${wg.work_groups_id}/works`);
+		works += ws.length;
+		for (const w of ws) {
+			const ts = await a.list(`/works/${w.works_id}/trains`);
+			trains += ts.length;
+			for (const t of ts) {
+				timetableRows += (await a.list(`/trains/${t.trains_id}/timetable_rows`)).length;
+			}
+		}
+	}
+	return {
+		lines: lines.length,
+		projectStations: stations.length,
+		colors: colors.length,
+		stopPatterns: stopPatterns.length,
+		workGroups: workGroups.length,
+		stationsOnLine,
+		stopPatternRows,
+		works,
+		trains,
+		timetableRows,
+	};
+}
+
+appTest("export → import reproduces the full project graph", async ({
+	appPage: page,
+	request,
+}) => {
+	const tok = await idToken(request);
+	const a = api(request, tok);
+
+	// ── Seed a rich source graph via the API ──
+	const projName = uniqueName("xport");
+	const proj = await a.post("/projects", { name: projName, description: "src" });
+	const pid = proj.projects_id;
+
+	const line = await a.post(`/projects/${pid}/lines`, { name: "L1", description: "" });
+	const st1 = await a.post(`/projects/${pid}/stations`, { name: "S1", description: "" });
+	const st2 = await a.post(`/projects/${pid}/stations`, { name: "S2", description: "" });
+	const color = await a.post(`/projects/${pid}/colors`, {
+		name: "C1",
+		description: "",
+		color_8bit: { red: 10, green: 20, blue: 30 },
+		color_real: { red: 10 / 255, green: 20 / 255, blue: 30 / 255 },
+	});
+	await a.post(`/lines/${line.lines_id}/stations_on_line`, {
+		lines_id: line.lines_id,
+		project_stations_id: st1.stations_id,
+		location_m: 0,
+	});
+	await a.post(`/lines/${line.lines_id}/stations_on_line`, {
+		lines_id: line.lines_id,
+		project_stations_id: st2.stations_id,
+		location_m: 1000,
+	});
+	const sp = await a.post(`/projects/${pid}/stop_patterns`, {
+		name: "P1",
+		lines_id: line.lines_id,
+	});
+	await a.post(`/stop_patterns/${sp.stop_patterns_id}/rows`, [
+		{ project_stations_id: st1.stations_id, sort_key: 0 },
+		{ project_stations_id: st2.stations_id, sort_key: 1 },
+	]);
+	const wg = await a.post(`/projects/${pid}/work_groups`, { name: "WG1", description: "" });
+	const work = await a.post(`/work_groups/${wg.work_groups_id}/works`, {
+		name: "WK1",
+		description: "",
+	});
+	const train = await a.post(`/works/${work.works_id}/trains`, {
+		train_number: "1M",
+		direction: 1,
+		day_count: 0,
+		description: "",
+	});
+	// Timetable row carries FKs (station + color marker) that must be remapped.
+	// description is a required field on timetable_rows (as on every entity).
+	await a.post(`/trains/${train.trains_id}/timetable_rows`, {
+		stations_id: st1.stations_id,
+		colors_id_marker: color.colors_id,
+		description: "",
+		drive_time_mm: 2,
+		drive_time_ss: 0,
+	});
+	await a.post(`/trains/${train.trains_id}/timetable_rows`, {
+		stations_id: st2.stations_id,
+		description: "",
+		drive_time_mm: 3,
+		drive_time_ss: 0,
+	});
+
+	const sourceCounts = await countGraph(request, tok, pid);
+	// Sanity: the seed actually produced a non-trivial graph.
+	expect(sourceCounts.timetableRows).toBe(2);
+	expect(sourceCounts.stationsOnLine).toBe(2);
+
+	// ── Export via the real UI (project card ⋯ menu → JSONとしてエクスポート) ──
+	page.on("dialog", (d) => void d.accept()); // confirm + alert on import
+	await page.reload();
+	const card = page.locator(".project-card").filter({ hasText: projName });
+	await expect(card).toBeVisible({ timeout: 10_000 });
+	await card.getByRole("button", { name: "⋯" }).click();
+	const [download] = await Promise.all([
+		page.waitForEvent("download"),
+		page.getByText("JSONとしてエクスポート").click(),
+	]);
+	const path = await download.path();
+	expect(path).toBeTruthy();
+
+	// ── Import the downloaded file via the real UI (hidden file input) ──
+	await page.locator('input[type="file"]').setInputFiles(path);
+
+	// Import completes (alert auto-accepted). Wait for a second project with the
+	// same name to materialise in the API.
+	await expect
+		.poll(
+			async () =>
+				(await a.list("/projects")).filter((p) => p.name === projName).length,
+			{ timeout: 20_000 }
+		)
+		.toBe(2);
+
+	// ── Verify the imported project reproduces every count ──
+	const projects = await a.list("/projects");
+	const imported = projects.find((p) => p.name === projName && p.projects_id !== pid);
+	expect(imported).toBeTruthy();
+	const importedCounts = await countGraph(request, tok, imported.projects_id);
+	expect(importedCounts).toEqual(sourceCounts);
+});

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,0 +1,58 @@
+// Shared E2E fixtures + helpers.
+//
+// `login(page)` drives the real sign-in form against the Firebase Auth
+// emulator (the user is provisioned in global-setup). It waits until the
+// AuthGate releases (the sign-in form detaches), which is the single
+// observable signal that `user !== null`.
+//
+// The `test` export is the standard Playwright test extended with an
+// `appPage` fixture: a page that is already signed in and sitting on the
+// project list.
+import { test as base, expect, type Page } from "@playwright/test";
+
+import { E2E_EMAIL, E2E_PASSWORD } from "./credentials";
+
+export { expect };
+
+export async function login(
+	page: Page,
+	email: string = E2E_EMAIL,
+	password: string = E2E_PASSWORD
+): Promise<void> {
+	await page.goto("/");
+	// AuthGate shows a loading splash, then the sign-in form.
+	const emailInput = page.locator("#auth-email");
+	await emailInput.waitFor({ state: "visible", timeout: 15_000 });
+	await emailInput.fill(email);
+	await page.locator("#auth-password").fill(password);
+	await page.locator('form button[type="submit"]').click();
+	// AuthGate releases → the sign-in form detaches.
+	await emailInput.waitFor({ state: "detached", timeout: 15_000 });
+}
+
+export const test = base.extend<{ appPage: Page }>({
+	appPage: async ({ page }, use) => {
+		// The Firebase Auth emulator injects a fixed-position warning banner at
+		// the bottom of the viewport ("Running in emulator mode..."). It overlaps
+		// page controls (e.g. the timetable grid's 行を追加 button) and intercepts
+		// pointer events, causing click timeouts. It's a test-only artifact, so
+		// hide it on every navigation/reload. addInitScript re-runs after reload.
+		await page.addInitScript(() => {
+			const inject = () => {
+				if (document.getElementById("e2e-hide-fb-banner")) return;
+				const style = document.createElement("style");
+				style.id = "e2e-hide-fb-banner";
+				style.textContent =
+					".firebase-emulator-warning{display:none !important;}";
+				(document.head ?? document.documentElement).appendChild(style);
+			};
+			if (document.readyState === "loading") {
+				document.addEventListener("DOMContentLoaded", inject);
+			} else {
+				inject();
+			}
+		});
+		await login(page);
+		await use(page);
+	},
+});

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -1,0 +1,43 @@
+// Playwright global setup — ensure the E2E user exists in the Firebase Auth
+// emulator with a password that satisfies the app's sign-in form validation
+// (8-32 chars, upper/lower/digit/symbol). The repo's seed users use password
+// "0000", which the form rejects, so we provision a compliant user via the
+// emulator REST API (idempotent: EMAIL_EXISTS is treated as success).
+import {
+	E2E_EMAIL,
+	E2E_PASSWORD,
+	E2E_EMAIL_2,
+	E2E_PASSWORD_2,
+} from "./credentials";
+
+const EMU_HOST = "localhost:9099";
+// The emulator does not validate the API key; any non-empty value works.
+const API_KEY = "e2e-fake-api-key";
+
+async function ensureUser(email: string, password: string): Promise<void> {
+	const url = `http://${EMU_HOST}/identitytoolkit.googleapis.com/v1/accounts:signUp?key=${API_KEY}`;
+	const res = await fetch(url, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ email, password, returnSecureToken: true }),
+	});
+	if (res.ok) return;
+	const body = (await res.json()) as { error?: { message?: string } };
+	if (body.error?.message === "EMAIL_EXISTS") return; // already provisioned
+	throw new Error(
+		`Failed to provision E2E user ${email} (${res.status}): ${JSON.stringify(body)}`
+	);
+}
+
+export default async function globalSetup(): Promise<void> {
+	// Fail fast with a clear message if the emulator is not up.
+	try {
+		await ensureUser(E2E_EMAIL, E2E_PASSWORD);
+		await ensureUser(E2E_EMAIL_2, E2E_PASSWORD_2);
+	} catch (e) {
+		throw new Error(
+			`E2E global setup failed. Is the backend stack up ` +
+				`(docker compose up -d php mysql firebase)? Cause: ${String(e)}`
+		);
+	}
+}

--- a/frontend/e2e/global-teardown.ts
+++ b/frontend/e2e/global-teardown.ts
@@ -1,0 +1,100 @@
+// Playwright global teardown — delete every project owned by the dedicated E2E
+// users after the suite finishes, so the shared dev DB never accumulates test
+// artifacts. WHY THIS MATTERS: each spec creates projects via the UI; with no
+// cleanup these pile up indefinitely (we found 639 stale ones), and the project
+// list's fetchAllPages + un-virtualized render then races the createProject
+// helper's card-visibility wait → flaky setup failures unrelated to any
+// assertion. Starting each run from a clean slate caps the in-run project count
+// at a single page, keeping setup fast. The E2E users are dedicated test
+// accounts (e2e-user@example.com / e2e-user2@example.com) with no real data, so
+// deleting ALL their projects is safe — it does NOT touch other users' data and
+// is NOT a DB wipe. See memory: e2e-createproject-flake-rootcause.
+import {
+	E2E_EMAIL,
+	E2E_PASSWORD,
+	E2E_EMAIL_2,
+	E2E_PASSWORD_2,
+} from "./credentials";
+
+const EMU_HOST = "localhost:9099";
+const API_KEY = "e2e-fake-api-key";
+// Same surface the tests hit: the Vite dev server (kept up by `webServer`)
+// proxies /api → the dockerized backend (:8080).
+const API_BASE = "http://localhost:5173/api/v1";
+const PAGE_LIMIT = 100;
+
+async function signIn(email: string, password: string): Promise<string | null> {
+	const url = `http://${EMU_HOST}/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=${API_KEY}`;
+	try {
+		const res = await fetch(url, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email, password, returnSecureToken: true }),
+		});
+		if (!res.ok) return null;
+		const body = (await res.json()) as { idToken?: string };
+		return body.idToken ?? null;
+	} catch {
+		return null;
+	}
+}
+
+async function deleteAllProjects(email: string, token: string): Promise<void> {
+	const auth = { Authorization: `Bearer ${token}` };
+	// Collect every project id across all pages first (deleting while paging
+	// would shift later pages).
+	const ids: string[] = [];
+	for (let p = 1; p <= 1000; p++) {
+		const res = await fetch(
+			`${API_BASE}/projects?p=${p}&limit=${PAGE_LIMIT}`,
+			{ headers: auth }
+		);
+		if (!res.ok) break;
+		const json = (await res.json()) as
+			| { data?: Array<{ projects_id?: string }> }
+			| Array<{ projects_id?: string }>;
+		const items = Array.isArray(json) ? json : (json.data ?? []);
+		for (const it of items) {
+			if (it.projects_id) ids.push(it.projects_id);
+		}
+		if (items.length < PAGE_LIMIT) break;
+	}
+	let deleted = 0;
+	for (const id of ids) {
+		try {
+			const res = await fetch(`${API_BASE}/projects/${id}`, {
+				method: "DELETE",
+				headers: auth,
+			});
+			if (res.ok) deleted++;
+		} catch {
+			// best-effort; teardown must not fail the run
+		}
+	}
+	// eslint-disable-next-line no-console
+	console.log(`[e2e teardown] ${email}: deleted ${deleted}/${ids.length} projects`);
+}
+
+export default async function globalTeardown(): Promise<void> {
+	// Best-effort: never throw — a teardown failure must not mask the actual
+	// test result. If the stack is already down, sign-in just returns null.
+	for (const [email, password] of [
+		[E2E_EMAIL, E2E_PASSWORD],
+		[E2E_EMAIL_2, E2E_PASSWORD_2],
+	] as const) {
+		try {
+			const token = await signIn(email, password);
+			if (token === null) {
+				// eslint-disable-next-line no-console
+				console.log(`[e2e teardown] ${email}: skipped (sign-in unavailable)`);
+				continue;
+			}
+			await deleteAllProjects(email, token);
+		} catch (e) {
+			// Stack unreachable / non-JSON response between the last test and
+			// teardown must NOT fail an otherwise-green run. Log and move on.
+			// eslint-disable-next-line no-console
+			console.log(`[e2e teardown] ${email}: skipped (${String(e)})`);
+		}
+	}
+}

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -1,0 +1,107 @@
+// Shared navigation / creation helpers for E2E specs.
+//
+// Default app language is "ja" (SettingsContext DEFAULTS, no browser
+// detection), so all label-based selectors use the Japanese strings from
+// src/i18n/strings.ts.
+//
+// These helpers assume create/open flows work; if one is broken the helper
+// throws, which is itself a finding (surface it in the spec, don't swallow).
+//
+// IMPORTANT for assertions: the app renders from the API (TanStack Query),
+// NOT from in-memory sample data. To prove a mutation actually persisted,
+// reload the page and assert the entity is still present.
+import { expect, type Page } from "@playwright/test";
+
+let counter = 0;
+/** Unique, human-readable name so parallel/repeated runs never collide. */
+export function uniqueName(prefix: string): string {
+	counter += 1;
+	// No Date.now() needed for uniqueness within a run; combine perf + counter.
+	return `${prefix}-${process.pid}-${counter}-${Math.floor(performance.now())}`;
+}
+
+/** The active modal dialog (`.modal` inside a backdrop). */
+export function modal(page: Page) {
+	return page.locator(".modal").last();
+}
+
+/** Click a footer/primary button by its visible label inside the active modal. */
+export async function clickModalButton(page: Page, label: string) {
+	await modal(page).getByRole("button", { name: label, exact: true }).click();
+}
+
+/* ─── Project ─────────────────────────────────────────────────────────── */
+
+export async function createProject(
+	page: Page,
+	name: string,
+	description = ""
+): Promise<void> {
+	await page
+		.getByRole("button", { name: /新規プロジェクト/ })
+		.first()
+		.click();
+	const m = modal(page);
+	await m.locator("input").first().fill(name);
+	if (description !== "") {
+		await m.locator("textarea").first().fill(description);
+	}
+	await clickModalButton(page, "保存");
+	// The list re-renders from the API; the card should appear.
+	await expect(
+		page.locator(".project-card").filter({ hasText: name })
+	).toBeVisible({ timeout: 10_000 });
+}
+
+export function projectCard(page: Page, name: string) {
+	return page.locator(".project-card").filter({ hasText: name });
+}
+
+export async function openProject(page: Page, name: string): Promise<void> {
+	// Click the card title (avoid the kebab "⋯" button).
+	await projectCard(page, name).locator("h3").click();
+	// Sidebar / work screen chrome should appear.
+	await expect(page.getByRole("button", { name: /路線・駅管理/ })).toBeVisible({
+		timeout: 10_000,
+	});
+}
+
+/* ─── Sidebar navigation ──────────────────────────────────────────────── */
+
+export async function gotoLines(page: Page): Promise<void> {
+	await page.getByRole("button", { name: /路線・駅管理/ }).click();
+}
+
+export async function gotoColors(page: Page): Promise<void> {
+	await page.getByRole("button", { name: /色マーカー管理/ }).click();
+}
+
+/* ─── WorkGroup / Work (sidebar) ──────────────────────────────────────── */
+
+export async function createWorkGroup(page: Page, name: string): Promise<void> {
+	await page.getByRole("button", { name: /新規WG/ }).first().click();
+	const m = modal(page);
+	await m.locator("input").first().fill(name);
+	await clickModalButton(page, "保存");
+	await expect(
+		page.locator(".sidebar-item").filter({ hasText: name })
+	).toBeVisible({ timeout: 10_000 });
+}
+
+export async function createWork(
+	page: Page,
+	wgName: string,
+	workName: string
+): Promise<void> {
+	// Expand the WG, then use its "＋ 新規ワーク" affordance.
+	const wgItem = page.locator(".sidebar-item").filter({ hasText: wgName });
+	await wgItem.first().click(); // toggle open
+	await page
+		.locator(".sidebar-item.indent")
+		.filter({ hasText: "新規ワーク" })
+		.first()
+		.click();
+	const m = modal(page);
+	await m.locator("input").first().fill(workName);
+	await clickModalButton(page, "保存");
+}

--- a/frontend/e2e/lines.spec.ts
+++ b/frontend/e2e/lines.spec.ts
@@ -1,0 +1,1050 @@
+/**
+ * e2e/lines.spec.ts — Lines & Stations manager (路線・駅管理) E2E spec.
+ *
+ * Covers:
+ *  - Line create / select / edit / delete
+ *  - Station create (via inline table) / edit / delete
+ *  - StationOnLine add / edit / delete / drag-reorder
+ *  - StationTrack (番線) create / edit / delete
+ *  - StopPattern wizard open / delete / duplicate
+ */
+import { test, expect } from "./fixtures";
+import {
+	createProject,
+	openProject,
+	gotoLines,
+	uniqueName,
+	modal,
+} from "./helpers";
+
+/* ─── Local helpers ──────────────────────────────────────────────────── */
+
+/**
+ * Locate a single stop-pattern list card by its name.
+ *
+ * Both the StopPatternCard (className="card") AND the surrounding line-detail
+ * card (also className="card", which *contains* the pattern cards) match a
+ * bare `.card` filter by pattern name — strict-mode violation. The line-detail
+ * card uniquely contains the tab labels "🚉 経由駅" / "🧩 停車パターン"; pattern
+ * cards never contain "経由駅", so `hasNotText: /経由駅/` excludes the outer card.
+ */
+function patternCard(page: import("@playwright/test").Page, name: string) {
+	return page
+		.locator(".card")
+		.filter({ hasText: name })
+		.filter({ hasNotText: /経由駅/ });
+}
+
+/**
+ * Wait for the LineManager to be rendered.
+ * Uses the "＋ 路線を追加" button that only appears on the lines screen.
+ */
+async function waitForLineManager(page: import("@playwright/test").Page) {
+	// The header has "路線・駅管理" as a h2 and there's a "＋ 路線を追加" button.
+	// We can't use getByRole("heading") reliably because it depends on the active tab.
+	// Instead, wait for the "路線を追加" button OR the main tabs to be visible.
+	await expect(
+		page.locator("button").filter({ hasText: /路線を追加|addLine/ }).first()
+	).toBeVisible({ timeout: 10_000 }).catch(async () => {
+		// fallback: wait for the two main tabs to appear
+		await expect(
+			page.getByRole("button", { name: /🛤 路線/ })
+		).toBeVisible({ timeout: 5_000 });
+	});
+}
+
+/**
+ * Open the "路線を追加" dialog, fill name, save.
+ * Waits for the new line to appear in the sidebar.
+ */
+async function addLine(
+	page: import("@playwright/test").Page,
+	name: string
+): Promise<void> {
+	await page.locator("button").filter({ hasText: /路線を追加/ }).first().click();
+	const m = modal(page);
+	await m.locator('input').first().fill(name);
+	await m.getByRole("button", { name: "保存" }).click();
+}
+
+/**
+ * Click the ⚙ settings button for a specific line in the sidebar list.
+ * The ⚙ is absolutely positioned inside the same relative-positioned div
+ * as the line's selection button.
+ */
+async function openLineSettingsDialog(
+	page: import("@playwright/test").Page,
+	lineName: string
+): Promise<void> {
+	// The line list item: a div > button(name) + button(⚙)
+	// We locate the ⚙ button that is a sibling of the line name button.
+	// The parent div wraps both buttons.
+	const lineItem = page.locator("div").filter({
+		has: page.locator("button").filter({ hasText: lineName }),
+	}).last();
+	await lineItem.getByRole("button", { name: "⚙" }).click();
+}
+
+/** Switch to the 駅（全体）main tab in LineManager. */
+async function gotoStationsTab(page: import("@playwright/test").Page) {
+	await page.getByRole("button", { name: /🚉 駅（全体）/ }).click();
+}
+
+/** Switch to the 🛤 路線 main tab in LineManager. */
+async function gotoLinesTab(page: import("@playwright/test").Page) {
+	// The tab button has EXACT text "🛤 路線" (as opposed to the sidebar button
+	// which reads "🛤 路線・駅管理"). Use the element that lives inside the tabs bar.
+	// The tabs are rendered as <button> elements with `style` and no class; we use
+	// exact text to avoid matching the sidebar item.
+	await page.locator("button", { hasText: /^🛤 路線$/ }).first().click();
+}
+
+/**
+ * Click the "新しい駅を追加" inline affordance in the Stations table,
+ * fill the station name, then confirm.
+ */
+async function createInlineStation(
+	page: import("@playwright/test").Page,
+	name: string
+): Promise<void> {
+	// Click the ＋ 新しい駅を追加 button (styled as a plain button at the bottom of the table)
+	await page.getByRole("button", { name: /新しい駅を追加/ }).click();
+	// Fill the first input in the new row (placeholder "駅名（短）")
+	await page.getByPlaceholder("駅名（短）").fill(name);
+	// Click ✓ 確定 button
+	await page.getByRole("button", { name: /✓ 確定/ }).click();
+}
+
+/**
+ * Select a line from the left sidebar by clicking its button.
+ * The line button appears in the "路線一覧" card.
+ */
+async function selectLine(
+	page: import("@playwright/test").Page,
+	lineName: string
+): Promise<void> {
+	// Line buttons are inside the "routes list" card on the left side.
+	// They contain the line name and match as a button text.
+	await page.locator("button").filter({ hasText: lineName }).first().click();
+}
+
+/**
+ * Helper to add a station to the currently visible line (LineStationsTab).
+ * Requires the 経由駅 tab to be active.
+ */
+async function addStationToActiveLine(
+	page: import("@playwright/test").Page,
+	stationName: string,
+	locationM: number
+): Promise<void> {
+	await page.getByRole("button", { name: /既存の駅を路線に追加/ }).click();
+	const sel = page.locator("select");
+	await expect(sel).toBeVisible({ timeout: 5_000 });
+	// selectOption label must be a string; stationName is unique so we match exactly
+	// The option text is "{stationName}（{fullName}）" so we must select by the station name prefix
+	// Use locator for the option element instead to avoid API constraint
+	const opt = sel.locator("option").filter({ hasText: stationName }).first();
+	const optValue = await opt.getAttribute("value");
+	if (optValue) {
+		await sel.selectOption(optValue);
+	} else {
+		// fallback: try by label string (non-regex)
+		await sel.selectOption({ label: stationName });
+	}
+	// The location_m input (number type in the new row)
+	const locInput = page.locator('input[type="number"]').first();
+	await locInput.click({ clickCount: 3 });
+	await locInput.fill(String(locationM));
+	await page.getByRole("button", { name: /✓ 追加/ }).click();
+	// Wait for the station to appear in the table
+	await expect(
+		page.locator("td").filter({ hasText: stationName }).first()
+	).toBeVisible({ timeout: 7_000 });
+}
+
+/* ─── Tests ──────────────────────────────────────────────────────────── */
+
+test.describe("Lines & Stations Manager", () => {
+
+	/* ── LINE CREATE ──────────────────────────────────────────────────── */
+
+	test("addLine: creates a line and it persists across reload", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", async (d) => { alerts.push(d.message()); await d.accept(); });
+
+		const proj = uniqueName("proj-line");
+		const lineName = uniqueName("line-A");
+
+		await createProject(page, proj);
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+
+		await addLine(page, lineName);
+
+		// Line should appear in the sidebar list immediately
+		await expect(
+			page.locator("button").filter({ hasText: lineName }).first()
+		).toBeVisible({ timeout: 7_000 });
+
+		// Persist check: reload — but after reload the app is on the project list,
+		// so we must navigate back.
+		await page.reload();
+		// After reload we're on the project list; navigate back
+		await expect(page.locator(".project-card").filter({ hasText: proj })).toBeVisible({ timeout: 10_000 });
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+
+		await expect(
+			page.locator("button").filter({ hasText: lineName }).first()
+		).toBeVisible({ timeout: 10_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	/* ── LINE EDIT ──────────────────────────────────────────────────── */
+
+	test("editLine: edits a line name and it persists", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", async (d) => { alerts.push(d.message()); await d.accept(); });
+
+		const proj = uniqueName("proj-ledit");
+		const lineName = uniqueName("line-edit");
+		const lineUpdated = uniqueName("line-edited");
+
+		await createProject(page, proj);
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+
+		await addLine(page, lineName);
+		await expect(
+			page.locator("button").filter({ hasText: lineName }).first()
+		).toBeVisible({ timeout: 7_000 });
+
+		// Open the ⚙ edit dialog
+		await openLineSettingsDialog(page, lineName);
+		const m = modal(page);
+		const nameInput = m.locator('input').first();
+		await nameInput.click({ clickCount: 3 });
+		await nameInput.fill(lineUpdated);
+		await m.getByRole("button", { name: "保存" }).click();
+
+		await expect(
+			page.locator("button").filter({ hasText: lineUpdated }).first()
+		).toBeVisible({ timeout: 7_000 });
+
+		// Persist check
+		await page.reload();
+		await expect(page.locator(".project-card").filter({ hasText: proj })).toBeVisible({ timeout: 10_000 });
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await expect(
+			page.locator("button").filter({ hasText: lineUpdated }).first()
+		).toBeVisible({ timeout: 10_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	/* ── LINE DELETE ──────────────────────────────────────────────────── */
+
+	test("deleteLine: deletes a line and it is gone after reload", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", async (d) => { alerts.push(d.message()); await d.accept(); });
+
+		const proj = uniqueName("proj-ldel");
+		const lineName = uniqueName("line-del");
+
+		await createProject(page, proj);
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+
+		await addLine(page, lineName);
+		await expect(
+			page.locator("button").filter({ hasText: lineName }).first()
+		).toBeVisible({ timeout: 7_000 });
+
+		// Open ⚙ dialog → click 削除 button
+		await openLineSettingsDialog(page, lineName);
+		const m = modal(page);
+		// In the LineDialog footer, the delete button has class btn-danger and text "🗑 削除"
+		await m.locator(".btn-danger").click();
+		// Native confirm fires → accepted by our handler above
+
+		// Line should disappear from the sidebar
+		await expect(
+			page.locator("button").filter({ hasText: lineName })
+		).toHaveCount(0, { timeout: 7_000 });
+
+		// Persist check
+		await page.reload();
+		await expect(page.locator(".project-card").filter({ hasText: proj })).toBeVisible({ timeout: 10_000 });
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await expect(
+			page.locator("button").filter({ hasText: lineName })
+		).toHaveCount(0);
+	});
+
+	/* ── STATION CREATE ──────────────────────────────────────────────── */
+
+	test("addStation (inline): creates a station and persists", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", async (d) => { alerts.push(d.message()); await d.accept(); });
+
+		const proj = uniqueName("proj-sta");
+		const stationName = uniqueName("sta-new");
+
+		await createProject(page, proj);
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+
+		await gotoStationsTab(page);
+		await createInlineStation(page, stationName);
+
+		// Should appear in the table
+		await expect(
+			page.locator("td").filter({ hasText: stationName }).first()
+		).toBeVisible({ timeout: 7_000 });
+
+		// Persist check
+		await page.reload();
+		await expect(page.locator(".project-card").filter({ hasText: proj })).toBeVisible({ timeout: 10_000 });
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await gotoStationsTab(page);
+		await expect(
+			page.locator("td").filter({ hasText: stationName }).first()
+		).toBeVisible({ timeout: 10_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	test("addStation (QuickAdd): creates a station and persists", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", async (d) => { alerts.push(d.message()); await d.accept(); });
+
+		const proj = uniqueName("proj-qsta");
+		const stationName = uniqueName("qsta");
+
+		await createProject(page, proj);
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await gotoStationsTab(page);
+
+		// QuickAdd: type into the placeholder "駅名を入力してEnter" field, then click 追加
+		const quickInput = page.getByPlaceholder(/駅名を入力してEnter/);
+		await quickInput.fill(stationName);
+		// Click the 追加 button next to the quick add input (btn-primary btn-sm)
+		await page.getByRole("button", { name: "追加" }).first().click();
+
+		await expect(
+			page.locator("td").filter({ hasText: stationName }).first()
+		).toBeVisible({ timeout: 7_000 });
+
+		// Persist check
+		await page.reload();
+		await expect(page.locator(".project-card").filter({ hasText: proj })).toBeVisible({ timeout: 10_000 });
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await gotoStationsTab(page);
+		await expect(
+			page.locator("td").filter({ hasText: stationName }).first()
+		).toBeVisible({ timeout: 10_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	/* ── STATION EDIT ──────────────────────────────────────────────── */
+
+	test("editStation: edits a station name and persists", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", async (d) => { alerts.push(d.message()); await d.accept(); });
+
+		const proj = uniqueName("proj-stedit");
+		const stationName = uniqueName("sta-orig");
+		const updatedName = uniqueName("sta-updated");
+
+		await createProject(page, proj);
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await gotoStationsTab(page);
+		await createInlineStation(page, stationName);
+
+		await expect(
+			page.locator("td").filter({ hasText: stationName }).first()
+		).toBeVisible({ timeout: 7_000 });
+
+		// Click on the station row to enter inline edit mode
+		// The station name is in a <td> — clicking the row triggers startEdit()
+		await page.locator("tr").filter({ hasText: stationName }).first().click();
+
+		// In edit mode, ICell renders an input. The first input in the editing row
+		// is the station name (stationName ICell). Because ICell passes `placeholder`
+		// only as attribute hint, and the input HAS a value, we target the input by
+		// its current value (which is the station name) to avoid ambiguity.
+		// We find the first text-type input that currently has stationName as value.
+		const nameInput = page.locator(`input[value="${stationName}"]`).first();
+		await expect(nameInput).toBeVisible({ timeout: 3_000 });
+		await nameInput.click({ clickCount: 3 });
+		await nameInput.fill(updatedName);
+		// Commit the edit
+		await page.getByRole("button", { name: /✓ 確定/ }).first().click();
+
+		await expect(
+			page.locator("td").filter({ hasText: updatedName }).first()
+		).toBeVisible({ timeout: 7_000 });
+
+		// Persist check
+		await page.reload();
+		await expect(page.locator(".project-card").filter({ hasText: proj })).toBeVisible({ timeout: 10_000 });
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await gotoStationsTab(page);
+		await expect(
+			page.locator("td").filter({ hasText: updatedName }).first()
+		).toBeVisible({ timeout: 10_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	/* ── STATION DELETE ──────────────────────────────────────────────── */
+
+	test("deleteStation: deletes a station and it is gone after reload", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", async (d) => { alerts.push(d.message()); await d.accept(); });
+
+		const proj = uniqueName("proj-stdel");
+		const stationName = uniqueName("sta-del");
+
+		await createProject(page, proj);
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await gotoStationsTab(page);
+		await createInlineStation(page, stationName);
+
+		await expect(
+			page.locator("td").filter({ hasText: stationName }).first()
+		).toBeVisible({ timeout: 7_000 });
+
+		// The station row (non-editing) shows a 🗑 button.
+		// We need to click the row to make the trash btn appear (it's always there
+		// in view mode as a btn-ghost in the last td).
+		const stationRow = page.locator("tr").filter({ hasText: stationName }).first();
+		// The last button in the row that is NOT the 🛤 trackManager button
+		// The row has two buttons: 🛤 and 🗑
+		// Use the one with color danger (🗑 has style color: danger)
+		// Simplest: get all buttons in the row and click the last one (🗑)
+		const rowBtns = stationRow.getByRole("button");
+		await rowBtns.last().click();
+		// Native confirm fires → accepted
+
+		await expect(
+			page.locator("td").filter({ hasText: stationName })
+		).toHaveCount(0, { timeout: 7_000 });
+
+		// Persist check
+		await page.reload();
+		await expect(page.locator(".project-card").filter({ hasText: proj })).toBeVisible({ timeout: 10_000 });
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await gotoStationsTab(page);
+		await expect(
+			page.locator("td").filter({ hasText: stationName })
+		).toHaveCount(0);
+	});
+
+	/* ── STATION ON LINE CRUD ────────────────────────────────────────── */
+
+	test("stationOnLine: add to line, persist, edit location, persist, delete, persist", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", async (d) => { alerts.push(d.message()); await d.accept(); });
+
+		const proj = uniqueName("proj-sol");
+		const lineName = uniqueName("line-sol");
+		const stationName = uniqueName("sta-sol");
+
+		await createProject(page, proj);
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+
+		// Create line
+		await addLine(page, lineName);
+		await expect(
+			page.locator("button").filter({ hasText: lineName }).first()
+		).toBeVisible({ timeout: 7_000 });
+
+		// Create station in the global stations tab
+		await gotoStationsTab(page);
+		await createInlineStation(page, stationName);
+		await expect(
+			page.locator("td").filter({ hasText: stationName }).first()
+		).toBeVisible({ timeout: 7_000 });
+
+		// Go back to lines tab, select our line
+		await gotoLinesTab(page);
+		await selectLine(page, lineName);
+
+		// Make sure 経由駅 sub-tab is active
+		await page.locator(".tab").filter({ hasText: /経由駅/ }).click();
+
+		// Add station to the line
+		await addStationToActiveLine(page, stationName, 1500);
+
+		// Persist check: reload
+		await page.reload();
+		await expect(page.locator(".project-card").filter({ hasText: proj })).toBeVisible({ timeout: 10_000 });
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await selectLine(page, lineName);
+		await page.locator(".tab").filter({ hasText: /経由駅/ }).click();
+		await expect(
+			page.locator("td").filter({ hasText: stationName }).first()
+		).toBeVisible({ timeout: 10_000 });
+
+		// Edit location_m: click on the row → inline edit mode
+		await page.locator("tr").filter({ hasText: stationName }).first().click();
+
+		// The edit mode for a sol row shows a number input for location_m
+		const locInput = page.locator('input[type="number"]').first();
+		await expect(locInput).toBeVisible({ timeout: 3_000 });
+		await locInput.click({ clickCount: 3 });
+		await locInput.fill("2500");
+		// Click the ✓ commit button (single checkmark, no extra text)
+		await page.locator("tr").filter({ hasText: stationName }).getByRole("button", { name: /^✓$/ }).click();
+
+		// Should show 2.5 km in the display
+		await expect(
+			page.locator("td").filter({ hasText: "2.5 km" })
+		).toBeVisible({ timeout: 7_000 });
+
+		// Persist check after edit
+		await page.reload();
+		await expect(page.locator(".project-card").filter({ hasText: proj })).toBeVisible({ timeout: 10_000 });
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await selectLine(page, lineName);
+		await page.locator(".tab").filter({ hasText: /経由駅/ }).click();
+		await expect(
+			page.locator("td").filter({ hasText: "2.5 km" })
+		).toBeVisible({ timeout: 10_000 });
+
+		// Delete station-on-line: click the row → edit mode → 🗑 button
+		await page.locator("tr").filter({ hasText: stationName }).first().click();
+		// In edit mode, the last button (🗑) in the row removes the station from line
+		const solRow = page.locator("tr").filter({ hasText: stationName }).first();
+		await solRow.getByRole("button").last().click();
+		// confirm dialog accepted automatically
+
+		await expect(
+			page.locator("td").filter({ hasText: stationName })
+		).toHaveCount(0, { timeout: 7_000 });
+
+		// Persist check after delete
+		await page.reload();
+		await expect(page.locator(".project-card").filter({ hasText: proj })).toBeVisible({ timeout: 10_000 });
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await selectLine(page, lineName);
+		await page.locator(".tab").filter({ hasText: /経由駅/ }).click();
+		await expect(
+			page.locator("td").filter({ hasText: stationName })
+		).toHaveCount(0);
+
+		// The removeSol function fires a native confirm() — that's expected UI behaviour.
+		// Only assert no error alerts (4xx/5xx) were fired.
+		const errorAlerts = alerts.filter(
+			(a) => /\d{3}|Error|エラー/i.test(a) && !/路線から除外|削除しますか/.test(a)
+		);
+		expect(errorAlerts).toHaveLength(0);
+	});
+
+	/* ── STATION ON LINE REORDER ─────────────────────────────────────── */
+
+	test("stationOnLine reorder: drag-to-reorder (UNSURE if unreliable)", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", async (d) => { alerts.push(d.message()); await d.accept(); });
+
+		const proj = uniqueName("proj-reorder");
+		const lineName = uniqueName("line-reorder");
+		const stationA = uniqueName("sta-RO-A");
+		const stationB = uniqueName("sta-RO-B");
+		const stationC = uniqueName("sta-RO-C");
+
+		await createProject(page, proj);
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+
+		// Create line
+		await addLine(page, lineName);
+		await expect(
+			page.locator("button").filter({ hasText: lineName }).first()
+		).toBeVisible({ timeout: 7_000 });
+
+		// Create 3 stations
+		await gotoStationsTab(page);
+		await createInlineStation(page, stationA);
+		await expect(page.locator("td").filter({ hasText: stationA }).first()).toBeVisible({ timeout: 7_000 });
+		await createInlineStation(page, stationB);
+		await expect(page.locator("td").filter({ hasText: stationB }).first()).toBeVisible({ timeout: 7_000 });
+		await createInlineStation(page, stationC);
+		await expect(page.locator("td").filter({ hasText: stationC }).first()).toBeVisible({ timeout: 7_000 });
+
+		// Add all 3 to the line at 1000m, 2000m, 3000m respectively
+		await gotoLinesTab(page);
+		await selectLine(page, lineName);
+		await page.locator(".tab").filter({ hasText: /経由駅/ }).click();
+
+		await addStationToActiveLine(page, stationA, 1000);
+		await addStationToActiveLine(page, stationB, 2000);
+		await addStationToActiveLine(page, stationC, 3000);
+
+		// Verify initial order: A(1.0 km), B(2.0 km), C(3.0 km)
+		const solRows = page.locator("tbody tr").filter({ has: page.locator("td").filter({ hasText: /km/ }) });
+		await expect(solRows.first()).toContainText(stationA, { timeout: 5_000 });
+
+		// Attempt drag: move stationC (row 3) above stationA (row 1)
+		const dragHandleForRow = (sName: string) =>
+			// The drag handle is the first <td> cell (⠿ character) in each row
+			page.locator("tr").filter({ hasText: sName }).first().locator("td").first();
+
+		const sourceCell = dragHandleForRow(stationC);
+		const targetCell = dragHandleForRow(stationA);
+
+		// Wait for the PUT reorder mutation to flush before reloading
+		const reorderResponsePromise = page.waitForResponse(
+			(r) => r.url().includes("stations_on_line") && r.request().method() === "PUT",
+			{ timeout: 10_000 }
+		).catch(() => null); // null if no PUT happens (drag did nothing)
+
+		await sourceCell.dragTo(targetCell);
+		await reorderResponsePromise;
+
+		// Reload and verify the new order persisted
+		await page.reload();
+		await expect(page.locator(".project-card").filter({ hasText: proj })).toBeVisible({ timeout: 10_000 });
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await selectLine(page, lineName);
+		await page.locator(".tab").filter({ hasText: /経由駅/ }).click();
+
+		// After drag reorder: C should be at position 1 (was moved above A)
+		const solRowsAfter = page.locator("tbody tr").filter({ has: page.locator("td").filter({ hasText: /km/ }) });
+		await expect(solRowsAfter.first()).toContainText(stationC, { timeout: 7_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	/* ── STATION TRACK (番線) CRUD ──────────────────────────────────── */
+
+	test("stationTrack: add track, persist, edit, persist, delete, persist", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", async (d) => { alerts.push(d.message()); await d.accept(); });
+
+		const proj = uniqueName("proj-trk");
+		const stationName = uniqueName("sta-trk");
+		const trackName = uniqueName("trk-1");
+		const trackUpdated = uniqueName("trk-upd");
+
+		await createProject(page, proj);
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await gotoStationsTab(page);
+		await createInlineStation(page, stationName);
+		await expect(
+			page.locator("td").filter({ hasText: stationName }).first()
+		).toBeVisible({ timeout: 7_000 });
+
+		// Open the StationTrackManager modal via the 🛤 button (title="番線管理")
+		const stationRow = page.locator("tr").filter({ hasText: stationName }).first();
+		await stationRow.getByTitle(/番線管理/).click();
+
+		const trkModal = modal(page);
+		await expect(trkModal).toBeVisible({ timeout: 5_000 });
+
+		// Click "＋ 番線を追加"
+		await trkModal.getByRole("button", { name: /番線を追加/ }).click();
+
+		// Fill the track name input (placeholder "1 / 上2 ...")
+		const trkInput = trkModal.locator('input[placeholder="1 / 上2 ..."]');
+		await expect(trkInput).toBeVisible({ timeout: 3_000 });
+		await trkInput.fill(trackName);
+
+		// Click 保存
+		await trkModal.getByRole("button", { name: "保存" }).click();
+
+		// Track should appear in the list inside the modal
+		await expect(
+			trkModal.locator("span").filter({ hasText: trackName })
+		).toBeVisible({ timeout: 7_000 });
+
+		// Close the modal
+		await trkModal.getByRole("button", { name: "✕" }).click();
+
+		// Reload and verify persistence
+		await page.reload();
+		await expect(page.locator(".project-card").filter({ hasText: proj })).toBeVisible({ timeout: 10_000 });
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await gotoStationsTab(page);
+
+		await page.locator("tr").filter({ hasText: stationName }).first().getByTitle(/番線管理/).click();
+		const trkModal2 = modal(page);
+		await expect(
+			trkModal2.locator("span").filter({ hasText: trackName })
+		).toBeVisible({ timeout: 10_000 });
+
+		// Edit the track: click 編集 button
+		await trkModal2.getByRole("button", { name: "編集" }).first().click();
+		const editInput = trkModal2.locator('input[placeholder="1 / 上2 ..."]');
+		await expect(editInput).toBeVisible({ timeout: 3_000 });
+		await editInput.click({ clickCount: 3 });
+		await editInput.fill(trackUpdated);
+		await trkModal2.getByRole("button", { name: "保存" }).click();
+
+		await expect(
+			trkModal2.locator("span").filter({ hasText: trackUpdated })
+		).toBeVisible({ timeout: 7_000 });
+
+		// Delete the track: click 🗑 button
+		await trkModal2.getByRole("button").filter({ hasText: /🗑/ }).click();
+
+		await expect(
+			trkModal2.locator("span").filter({ hasText: trackUpdated })
+		).toHaveCount(0, { timeout: 7_000 });
+
+		// Close and reload to verify deletion persisted
+		await trkModal2.getByRole("button", { name: "✕" }).click();
+		await page.reload();
+		await expect(page.locator(".project-card").filter({ hasText: proj })).toBeVisible({ timeout: 10_000 });
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await gotoStationsTab(page);
+
+		await page.locator("tr").filter({ hasText: stationName }).first().getByTitle(/番線管理/).click();
+		const trkModal3 = modal(page);
+		await expect(
+			trkModal3.locator("span").filter({ hasText: trackUpdated })
+		).toHaveCount(0);
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	/* ── STOP PATTERN: WIZARD OPEN ──────────────────────────────────── */
+
+	test("stopPattern wizard: opens on click and can be closed", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", async (d) => { alerts.push(d.message()); await d.accept(); });
+
+		const proj = uniqueName("proj-spwiz");
+		const lineName = uniqueName("line-spwiz");
+
+		await createProject(page, proj);
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+
+		await addLine(page, lineName);
+		await expect(
+			page.locator("button").filter({ hasText: lineName }).first()
+		).toBeVisible({ timeout: 7_000 });
+
+		await selectLine(page, lineName);
+		// Switch to 停車パターン sub-tab
+		await page.locator(".tab").filter({ hasText: /停車パターン/ }).click();
+
+		// Click the wizard button
+		await page.getByRole("button", { name: /ウィザードで作成/ }).click();
+
+		// The StopPatternWizard should mount — verify step 1 is visible
+		await expect(
+			page.getByText(/路線・区間を選択/)
+		).toBeVisible({ timeout: 7_000 });
+
+		// Close wizard via the ✕ button
+		await page.getByRole("button", { name: "✕" }).first().click();
+
+		// Wizard should be gone
+		await expect(
+			page.getByText(/路線・区間を選択/)
+		).toHaveCount(0, { timeout: 5_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	/* ── STOP PATTERN: CREATE / EDIT / DELETE / DUPLICATE ──────────── */
+
+	test("stopPattern: create, reload (persist), edit, delete, duplicate — all persist", async ({
+		appPage: page,
+	}) => {
+		// Stop-pattern create/edit/delete/duplicate all persist. Pattern cards are
+		// located via the patternCard() helper, which excludes the surrounding
+		// line-detail card (that card *contains* the pattern cards and would
+		// otherwise produce a strict-mode "2 elements" failure).
+		// This test runs the full wizard flow 3× with 3 reloads → needs > 30s.
+		test.setTimeout(90_000);
+		const alerts: string[] = [];
+		page.on("dialog", async (d) => {
+			alerts.push(d.message());
+			await d.accept();
+		});
+
+		const proj = uniqueName("proj-spcd");
+		const lineName = uniqueName("line-spcd");
+		const stationA = uniqueName("sta-spA");
+		const stationB = uniqueName("sta-spB");
+		const patternName = uniqueName("pat");
+
+		await createProject(page, proj);
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+
+		// Create line
+		await addLine(page, lineName);
+		await expect(
+			page.locator("button").filter({ hasText: lineName }).first()
+		).toBeVisible({ timeout: 7_000 });
+
+		// Create 2 stations
+		await gotoStationsTab(page);
+		await createInlineStation(page, stationA);
+		await expect(page.locator("td").filter({ hasText: stationA }).first()).toBeVisible({ timeout: 7_000 });
+		await createInlineStation(page, stationB);
+		await expect(page.locator("td").filter({ hasText: stationB }).first()).toBeVisible({ timeout: 7_000 });
+
+		// Add both stations to the line
+		await gotoLinesTab(page);
+		await selectLine(page, lineName);
+		await page.locator(".tab").filter({ hasText: /経由駅/ }).click();
+		await addStationToActiveLine(page, stationA, 1000);
+		await addStationToActiveLine(page, stationB, 2000);
+
+		// Switch to 停車パターン sub-tab
+		await page.locator(".tab").filter({ hasText: /停車パターン/ }).click();
+
+		// Open wizard
+		await page.getByRole("button", { name: /ウィザードで作成/ }).click();
+		await expect(page.getByText(/路線・区間を選択/)).toBeVisible({ timeout: 7_000 });
+
+		// Step 1: select the line
+		// The StopPatternWizard shows a <select> for line selection
+		const lineSelect = page.locator("select").first();
+		await expect(lineSelect).toBeVisible({ timeout: 5_000 });
+		// selectOption label must be string; use value-based selection from option element
+		const lineOpt = lineSelect.locator("option").filter({ hasText: lineName }).first();
+		const lineOptVal = await lineOpt.getAttribute("value");
+		if (lineOptVal) {
+			await lineSelect.selectOption(lineOptVal);
+		} else {
+			await lineSelect.selectOption({ label: lineName });
+		}
+
+		// Select direction (↓ 下り = direction 1)
+		await page.getByRole("button", { name: /↓ 下り/ }).click();
+
+		// After selecting direction, the from/to station selects appear
+		// Select fromStation (stationA) and toStation (stationB)
+		const fromSelect = page.locator("select").nth(1);
+		await expect(fromSelect).toBeVisible({ timeout: 5_000 });
+		const fromOpt = fromSelect.locator("option").filter({ hasText: stationA }).first();
+		const fromOptVal = await fromOpt.getAttribute("value");
+		if (fromOptVal) {
+			await fromSelect.selectOption(fromOptVal);
+		}
+
+		// After selecting from station, to station select is enabled
+		const toSelect = page.locator("select").nth(2);
+		await expect(toSelect).toBeEnabled({ timeout: 3_000 });
+		const toOpt = toSelect.locator("option").filter({ hasText: stationB }).first();
+		const toOptVal = await toOpt.getAttribute("value");
+		if (toOptVal) {
+			await toSelect.selectOption(toOptVal);
+		}
+
+		// After selecting from/to, the pattern name input appears in step 1
+		// (パターン名 field, placeholder "例: 快速停車パターン")
+		const patNameInput = page.getByPlaceholder(/快速停車パターン/);
+		await expect(patNameInput).toBeVisible({ timeout: 3_000 });
+		await patNameInput.fill(patternName);
+
+		// Now the 次へ button should be enabled
+		await expect(page.getByRole("button", { name: "次へ" })).toBeEnabled({ timeout: 3_000 });
+
+		// Click 次へ to go to step 2
+		await page.getByRole("button", { name: "次へ" }).click();
+
+		// Step 2: set stop pattern (station stop settings grid — no name input here)
+		// Use the wizard step label (exact text) to avoid matching the description paragraph
+		await expect(
+			page.locator(".wizard-step-label", { hasText: "停車パターンを設定" }).first()
+		).toBeVisible({ timeout: 7_000 });
+
+		// Click 次へ to go to step 3
+		await page.getByRole("button", { name: "次へ" }).click();
+
+		// Step 3: confirmation
+		await expect(
+			page.getByText(/確認/)
+		).toBeVisible({ timeout: 7_000 });
+
+		// Click 完了 / 保存 to finish
+		const finishBtn = page.getByRole("button", { name: /完了|保存/ }).last();
+		await finishBtn.click();
+
+		// Wizard should close
+		await expect(page.getByText(/路線・区間を選択/)).toHaveCount(0, { timeout: 10_000 });
+
+		// Pattern card should appear in 停車パターン tab
+		// Give a brief moment for TanStack Query to refetch
+		await page.waitForTimeout(500);
+
+		await expect(
+			patternCard(page, patternName)
+		).toBeVisible({ timeout: 10_000 });
+
+		// ── Persist check for create ──
+		// Let in-flight writes settle so reload doesn't abort them ("Failed to
+		// fetch") — mirrors reloadAndNavigate's documented pattern.
+		await page.waitForLoadState("networkidle");
+		await page.reload();
+		await expect(page.locator(".project-card").filter({ hasText: proj })).toBeVisible({ timeout: 10_000 });
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await selectLine(page, lineName);
+		await page.locator(".tab").filter({ hasText: /停車パターン/ }).click();
+		await expect(
+			patternCard(page, patternName)
+		).toBeVisible({ timeout: 10_000 });
+
+		// ── DUPLICATE ──
+		const patCard = patternCard(page, patternName).first();
+		await patCard.getByRole("button", { name: /複製|⎘/ }).click();
+
+		const copyName = patternName + " (コピー)";
+		await expect(
+			patternCard(page, copyName)
+		).toBeVisible({ timeout: 10_000 });
+
+		// Persist check for duplicate
+		await page.waitForLoadState("networkidle");
+		await page.reload();
+		await expect(page.locator(".project-card").filter({ hasText: proj })).toBeVisible({ timeout: 10_000 });
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await selectLine(page, lineName);
+		await page.locator(".tab").filter({ hasText: /停車パターン/ }).click();
+		await expect(
+			patternCard(page, copyName)
+		).toBeVisible({ timeout: 10_000 });
+
+		// ── EDIT pattern (open wizard in edit mode) ──
+		// Click the ✏ 編集 button on the pattern card.
+		// At this point both the original card and the "コピー" copy are visible;
+		// filter hasNotText: "コピー" to unambiguously select the original.
+		const origCardForEdit = patternCard(page, patternName).filter({ hasNotText: "コピー" });
+		await origCardForEdit.getByRole("button", { name: /編集|✏/ }).click();
+
+		// The wizard opens in edit mode
+		await expect(
+			page.getByText(/路線・区間を選択/)
+		).toBeVisible({ timeout: 7_000 });
+
+		// Step 1 in edit mode — the pattern name input is here (pre-filled)
+		// Update the pattern name before clicking 次へ
+		const editedPatternName = patternName + "-edited";
+		const editPatNameInput = page.getByPlaceholder(/快速停車パターン/);
+		if (await editPatNameInput.count() > 0) {
+			await editPatNameInput.click({ clickCount: 3 });
+			await editPatNameInput.fill(editedPatternName);
+		}
+		await page.getByRole("button", { name: "次へ" }).click();
+
+		// Step 2: stop pattern settings grid
+		await expect(
+			page.locator(".wizard-step-label", { hasText: "停車パターンを設定" }).first()
+		).toBeVisible({ timeout: 7_000 });
+		await page.getByRole("button", { name: "次へ" }).click();
+
+		// Step 3 — in edit mode the confirm button reads "更新" (not 完了/保存)
+		await expect(page.getByText(/確認/)).toBeVisible({ timeout: 7_000 });
+		await page.getByRole("button", { name: /完了|保存|更新/ }).last().click();
+
+		// Wizard closes
+		await expect(page.getByText(/路線・区間を選択/)).toHaveCount(0, { timeout: 10_000 });
+
+		// ── DELETE the copy ──
+		const copyCard = patternCard(page, copyName).first();
+		await copyCard.getByRole("button").filter({ hasText: /🗑/ }).click();
+		// confirm → accepted
+
+		await expect(
+			patternCard(page, copyName)
+		).toHaveCount(0, { timeout: 7_000 });
+
+		// Persist check for deletion
+		await page.waitForLoadState("networkidle");
+		await page.reload();
+		await expect(page.locator(".project-card").filter({ hasText: proj })).toBeVisible({ timeout: 10_000 });
+		await openProject(page, proj);
+		await gotoLines(page);
+		await waitForLineManager(page);
+		await selectLine(page, lineName);
+		await page.locator(".tab").filter({ hasText: /停車パターン/ }).click();
+		// Copy should be gone
+		await expect(
+			patternCard(page, copyName)
+		).toHaveCount(0);
+
+		// The delete fires a confirm("…削除しますか") dialog, which the handler
+		// captures — that's expected. Assert it happened AND that no *other*
+		// alert leaked (a real error like "Failed to fetch" would still fail).
+		expect(alerts.some(a => a.includes("削除しますか"))).toBe(true);
+		expect(alerts.filter(a => !a.includes("削除しますか"))).toEqual([]);
+	});
+});

--- a/frontend/e2e/projects.spec.ts
+++ b/frontend/e2e/projects.spec.ts
@@ -1,0 +1,373 @@
+// E2E spec for the Projects list screen.
+//
+// Export/import are now API-backed (transfer.ts → backend export/import
+// endpoints): the toolbar "📤 エクスポート" downloads a BUNDLE_KIND bundle of
+// every project's graph, the card-menu "JSONとしてエクスポート" downloads a
+// single project graph, and "📥 インポート" recreates a project from a v3
+// graph file. The tests below exercise that real behaviour.
+import * as fs from "fs";
+
+import { test, expect } from "./fixtures";
+import {
+	createProject,
+	projectCard,
+	uniqueName,
+	modal,
+	clickModalButton,
+} from "./helpers";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers local to this spec
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Open the kebab context menu for a named project card. */
+async function openKebabMenu(page: import("@playwright/test").Page, name: string) {
+	const card = projectCard(page, name);
+	// The kebab button renders "⋯" text and has title="メニュー".
+	// Use getByTitle which matches the title attribute.
+	await card.getByTitle("メニュー").click();
+}
+
+/** Click a context-menu item by label text. */
+async function clickMenuItemByLabel(
+	page: import("@playwright/test").Page,
+	label: string
+) {
+	// The context menu is a fixed-position div, not a .modal.
+	// Items are buttons with text matching the label.
+	await page.locator(`button:has-text("${label}")`).first().click();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. "＋ 新規プロジェクト" toolbar button
+// ─────────────────────────────────────────────────────────────────────────────
+test("toolbar ＋新規プロジェクト button — creates card, persists across reload", async ({
+	appPage: page,
+}) => {
+	const alerts: string[] = [];
+	page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+	const name = uniqueName("proj-toolbar");
+
+	// Use the helper which clicks the toolbar button and asserts the card appears.
+	await createProject(page, name);
+
+	// Verify the card is present before reload.
+	await expect(projectCard(page, name)).toBeVisible();
+
+	// Reload and confirm persistence (API-backed).
+	await page.reload();
+	await expect(projectCard(page, name)).toBeVisible({ timeout: 10_000 });
+
+	expect(alerts, "no backend error alerts").toEqual([]);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. ".card-add" div (also calls onNew)
+// ─────────────────────────────────────────────────────────────────────────────
+test(".card-add div — creates card, persists across reload", async ({
+	appPage: page,
+}) => {
+	const alerts: string[] = [];
+	page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+	const name = uniqueName("proj-card-add");
+
+	// Click the card-add div directly (not the toolbar button).
+	await page.locator(".card-add").click();
+	const m = modal(page);
+	await m.locator("input").first().fill(name);
+	await clickModalButton(page, "保存");
+
+	// Card should appear.
+	await expect(projectCard(page, name)).toBeVisible({ timeout: 10_000 });
+
+	// Persist check.
+	await page.reload();
+	await expect(projectCard(page, name)).toBeVisible({ timeout: 10_000 });
+
+	expect(alerts).toEqual([]);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Project card click — opens the project (navigates away from list)
+// ─────────────────────────────────────────────────────────────────────────────
+test("project card click — opens the project work screen", async ({
+	appPage: page,
+}) => {
+	const alerts: string[] = [];
+	page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+	const name = uniqueName("proj-card-click");
+	await createProject(page, name);
+
+	// Click the card body (h3 title area to avoid the kebab button).
+	await projectCard(page, name).locator("h3").click();
+
+	// After opening a project, the sidebar shows project-management buttons.
+	await expect(page.getByRole("button", { name: /路線・駅管理/ })).toBeVisible({
+		timeout: 10_000,
+	});
+
+	expect(alerts).toEqual([]);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Kebab "⋯" menu → 開く
+// ─────────────────────────────────────────────────────────────────────────────
+test("kebab menu → 開く — opens the project work screen", async ({
+	appPage: page,
+}) => {
+	const alerts: string[] = [];
+	page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+	const name = uniqueName("proj-kebab-open");
+	await createProject(page, name);
+
+	await openKebabMenu(page, name);
+	await clickMenuItemByLabel(page, "開く");
+
+	await expect(page.getByRole("button", { name: /路線・駅管理/ })).toBeVisible({
+		timeout: 10_000,
+	});
+
+	expect(alerts).toEqual([]);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Kebab menu → 編集 → save → persists across reload
+// ─────────────────────────────────────────────────────────────────────────────
+test("kebab menu → 編集 — edits project name, persists across reload", async ({
+	appPage: page,
+}) => {
+	const alerts: string[] = [];
+	page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+	const origName = uniqueName("proj-edit-before");
+	const newName = uniqueName("proj-edit-after");
+	await createProject(page, origName);
+
+	await openKebabMenu(page, origName);
+	await clickMenuItemByLabel(page, "編集");
+
+	const m = modal(page);
+	// Clear and re-fill the name field.
+	await m.locator("input").first().clear();
+	await m.locator("input").first().fill(newName);
+	await clickModalButton(page, "保存");
+
+	// Card with new name should appear.
+	await expect(projectCard(page, newName)).toBeVisible({ timeout: 10_000 });
+
+	// Reload and verify persistence.
+	await page.reload();
+	await expect(projectCard(page, newName)).toBeVisible({ timeout: 10_000 });
+	// Old name should be gone.
+	await expect(projectCard(page, origName)).toHaveCount(0);
+
+	expect(alerts).toEqual([]);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. Right-click (contextmenu) on card → same menu appears
+// ─────────────────────────────────────────────────────────────────────────────
+test("right-click on card — context menu appears with all items", async ({
+	appPage: page,
+}) => {
+	const name = uniqueName("proj-rightclick");
+	await createProject(page, name);
+
+	// Right-click the card body (not the kebab button).
+	const card = projectCard(page, name);
+	// dispatchEvent on the card to fire contextmenu event.
+	await card.dispatchEvent("contextmenu");
+
+	// Verify the expected menu items are visible.
+	// Items render as buttons with icon + label in spans.
+	await expect(page.locator('button:has-text("開く")')).toBeVisible({
+		timeout: 5_000,
+	});
+	await expect(page.locator('button:has-text("編集")')).toBeVisible();
+	await expect(page.locator('button:has-text("JSONとしてエクスポート")')).toBeVisible();
+	await expect(page.locator('button:has-text("削除")')).toBeVisible();
+
+	// Close by pressing Escape.
+	await page.keyboard.press("Escape");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. Kebab menu → 削除 → ConfirmDialog → card gone after reload
+// ─────────────────────────────────────────────────────────────────────────────
+test("kebab menu → 削除 → confirm → card gone after reload", async ({
+	appPage: page,
+}) => {
+	const alerts: string[] = [];
+	page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+	const name = uniqueName("proj-delete");
+	await createProject(page, name);
+
+	await openKebabMenu(page, name);
+	await clickMenuItemByLabel(page, "削除");
+
+	// ConfirmDialog should appear (custom modal, NOT native confirm).
+	await expect(modal(page)).toBeVisible({ timeout: 5_000 });
+	// Click the danger "削除" button inside the modal.
+	await clickModalButton(page, "削除");
+
+	// Card should disappear.
+	await expect(projectCard(page, name)).toHaveCount(0, { timeout: 10_000 });
+
+	// Reload and confirm it's gone (API-backed).
+	await page.reload();
+	await expect(projectCard(page, name)).toHaveCount(0, { timeout: 10_000 });
+
+	expect(alerts).toEqual([]);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 8. Toolbar 📤 エクスポート (export all) — downloads a BUNDLE_KIND bundle that
+//    contains every API project's graph. The bundle shape is
+//    { version, kind: BUNDLE_KIND, exportedAt, graphs: [ { project: {...}, ...} ] }
+//    (App.tsx exportAll + transfer.ts). The previous test asserted the obsolete
+//    json.projects[].name shape and timed out (exportAll fan-out via Promise.all
+//    over the whole DB). exportAll is now a bounded sequential loop; this test
+//    asserts the new bundle shape and that one graph carries our project name.
+// ─────────────────────────────────────────────────────────────────────────────
+test("toolbar 📤エクスポート — download bundle contains API-created project", async ({
+	appPage: page,
+}) => {
+	// Exporting ALL projects (the dev DB has many) can be slow even when bounded.
+	test.setTimeout(120_000);
+
+	const name = uniqueName("proj-export-all");
+	await createProject(page, name);
+
+	// Capture the download. Generous timeout — export-all walks every project.
+	const [dl] = await Promise.all([
+		page.waitForEvent("download", { timeout: 90_000 }),
+		page.getByRole("button", { name: /エクスポート/ }).click(),
+	]);
+
+	const path = await dl.path();
+	expect(path, "download should have a file path").toBeTruthy();
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+	const json = JSON.parse(fs.readFileSync(path!, "utf-8"));
+
+	// New bundle shape.
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+	expect(json.kind, "bundle kind").toBe("trvis-project-graph-bundle");
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+	expect(Array.isArray(json.graphs), "bundle has graphs array").toBe(true);
+
+	// Our API-created project should appear as one graph (graph.project.name).
+	const graphs = (json as { graphs: Array<{ project?: { name?: string } }> })
+		.graphs;
+	const graphNames = graphs.map((g) => g.project?.name);
+	expect(
+		graphNames,
+		"exported bundle should contain the API-created project"
+	).toContain(name);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 9. Card-menu "JSONとしてエクスポート" — a download fires.
+//    exportProject(pid) now reads apiProjects and calls exportProjectGraph(pid)
+//    (App.tsx), so the API project id resolves and a download is produced.
+//    (Previously read in-memory sample data → find() undefined → no download.)
+// ─────────────────────────────────────────────────────────────────────────────
+test("card menu JSONとしてエクスポート — downloads project JSON", async ({
+	appPage: page,
+}) => {
+	const name = uniqueName("proj-export-single");
+	await createProject(page, name);
+
+	// Set up a download listener before clicking.
+	const dlPromise = page.waitForEvent("download", { timeout: 5_000 }).catch(() => null);
+
+	await openKebabMenu(page, name);
+	await clickMenuItemByLabel(page, "JSONとしてエクスポート");
+
+	const dl = await dlPromise;
+
+	// A download should fire containing our project (exportProject now reads
+	// apiProjects → exportProjectGraph, so the API id resolves).
+	expect(dl, "card export should trigger a download").not.toBeNull();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 10. 📥 インポート — importing a valid project-graph JSON adds a card.
+//     The importer accepts the new server-side format (transfer.ts:
+//     TRANSFER_KIND="trvis-project-graph", v3, shape { version, kind,
+//     exportedAt, graph }). The previous test wrote the obsolete v1
+//     "trvis-project" format which the importer correctly rejects.
+//     Rewritten to produce a REAL graph file by exporting an API-created
+//     project via the UI, then re-importing it — the import creates a fresh
+//     project with the same name, so a second card with that name appears.
+//     (Mirrors export-import.spec.ts's full round-trip, minimally.)
+// ─────────────────────────────────────────────────────────────────────────────
+test("📥インポート — re-importing an exported project adds a new card", async ({
+	appPage: page,
+}) => {
+	const alerts: string[] = [];
+	page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+	const name = uniqueName("proj-import-roundtrip");
+	await createProject(page, name);
+
+	// Export the project via the card kebab menu → produces a valid v3
+	// graph file (the only format the importer accepts).
+	await openKebabMenu(page, name);
+	const [download] = await Promise.all([
+		page.waitForEvent("download", { timeout: 10_000 }),
+		clickMenuItemByLabel(page, "JSONとしてエクスポート"),
+	]);
+	const exportPath = await download.path();
+	expect(exportPath, "export should produce a file").toBeTruthy();
+
+	// Re-import the exported file via the hidden file input.
+	const fileInput = page.locator('input[type="file"][accept*="json"]');
+	await fileInput.setInputFiles(exportPath!);
+
+	// Import must not emit a format error.
+	await page.waitForTimeout(1_000); // FileReader + React tick
+	const formatError = alerts.find((a) => a.includes("未対応"));
+	expect(formatError, "import should not emit a format error").toBeUndefined();
+
+	// The import creates a fresh project with the same name, so there are now
+	// TWO cards with that name (the original + the imported copy).
+	await expect(projectCard(page, name)).toHaveCount(2, { timeout: 15_000 });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 11. "再試行" retry button (best-effort: intercept network error, click retry)
+// ─────────────────────────────────────────────────────────────────────────────
+test("再試行 button — appears on error and retriggers the projects query", async ({
+	appPage: page,
+}) => {
+	// Intercept the projects API to return a 500 error.
+	await page.route("**/api/v1/projects**", (route) => {
+		void route.fulfill({
+			status: 500,
+			contentType: "application/json",
+			body: JSON.stringify({ message: "simulated server error" }),
+		});
+	});
+
+	// Reload so the intercepted 500 is seen on the initial fetch.
+	await page.reload();
+
+	// The error banner with 再試行 should appear.
+	const retryButton = page.getByRole("button", { name: "再試行" });
+	await expect(retryButton).toBeVisible({ timeout: 10_000 });
+
+	// Unroute so the retry can succeed.
+	await page.unroute("**/api/v1/projects**");
+
+	await retryButton.click();
+
+	// After retry the error banner should disappear and the grid should render.
+	await expect(retryButton).toHaveCount(0, { timeout: 10_000 });
+	// The card-add affordance is rendered when there's no error.
+	await expect(page.locator(".card-add")).toBeVisible({ timeout: 10_000 });
+});

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect, login } from "./fixtures";
+
+test.describe("smoke", () => {
+	test("auth gate shows sign-in form when unauthenticated", async ({
+		page,
+	}) => {
+		await page.goto("/");
+		await expect(page.locator("#auth-email")).toBeVisible({
+			timeout: 15_000,
+		});
+		await expect(page.locator("#auth-password")).toBeVisible();
+	});
+
+	test("can sign in and reach the project list", async ({ page }) => {
+		await login(page);
+		// After the gate releases, the project list screen renders. It has a
+		// "new project" affordance; assert the app chrome is present rather
+		// than the auth form.
+		await expect(page.locator("#auth-email")).toHaveCount(0);
+		// The page should now contain interactive app content.
+		await expect(page.locator("body")).toBeVisible();
+	});
+});

--- a/frontend/e2e/timetable.spec.ts
+++ b/frontend/e2e/timetable.spec.ts
@@ -1,0 +1,1367 @@
+/**
+ * TimetableGrid E2E spec.
+ *
+ * Setup chain per-test:
+ *   1. createProject → openProject
+ *   2. createWorkGroup → createWork  (sidebar)
+ *   3. gotoLines → "🚉 駅（全体）" tab → quick-add 2 stations
+ *   4. Navigate back to the work → create a train (click ＋ 新規列車) →
+ *      click the train in the list to select it (sets currentTrain state)
+ *
+ * App.tsx has NO router — all state is React state. After page.reload() we
+ * must re-navigate the full tree to reach the grid.
+ *
+ * Drag-reorder: .drag-handle CSS class exists but no draggable attribute is
+ * rendered on StationRow → UNIMPLEMENTED.
+ *
+ * arriveHidden / departureHidden / showHH are model-only fields; they are
+ * never written into modelRowToEntityDraft in App.tsx → won't persist → WRONG-SOURCE.
+ */
+
+import { test, expect } from "./fixtures";
+import {
+  uniqueName,
+  createProject,
+  openProject,
+  createWorkGroup,
+  gotoLines,
+} from "./helpers";
+
+/* ─── local navigation helpers ─────────────────────────────────────────── */
+
+/**
+ * Workaround: after openProject with no WGs, the main content area shows
+ * an extra "新規WG" button alongside the sidebar one, causing strict-mode
+ * violations in helpers.createWorkGroup. Navigate to "lines" first so the
+ * main area shows LineManager instead of the empty-state, leaving only the
+ * sidebar button visible.
+ */
+async function safeCreateWorkGroup(
+  page: import("@playwright/test").Page,
+  wgName: string
+) {
+  // Switch to lines screen so the main content area no longer shows the
+  // duplicate "新規WG" button in the empty-state.
+  await gotoLines(page);
+  await createWorkGroup(page, wgName);
+}
+
+/**
+ * Local createWork — identical to helpers.createWork but clears the
+ * affectDate field before saving.
+ *
+ * WHY: The WorkDialog pre-fills affectDate with today's date (a string
+ * "YYYY-MM-DD"). The backend POST /work_groups/{id}/works passes that string
+ * directly to WorksRepo::insertWork(?DateTimeInterface $affectDate), which
+ * throws a TypeError → HTTP 500. Clearing the field makes the body send
+ * affect_date: null / omit it, which the backend accepts (nullable column).
+ */
+async function localCreateWork(
+  page: import("@playwright/test").Page,
+  wgName: string,
+  workName: string
+): Promise<void> {
+  // WG may be expanded already (after safeCreateWorkGroup calls gotoLines first,
+  // then createWorkGroup — which expands the WG). Try clicking "新規ワーク" directly;
+  // if not visible, click the WG to expand first.
+  const newWorkBtn = page
+    .locator(".sidebar-item.indent")
+    .filter({ hasText: "新規ワーク" })
+    .first();
+  const isVisible = await newWorkBtn.isVisible({ timeout: 2_000 }).catch(() => false);
+  if (!isVisible) {
+    await page.locator(".sidebar-item").filter({ hasText: wgName }).first().click();
+    await expect(newWorkBtn).toBeVisible({ timeout: 5_000 });
+  }
+  await newWorkBtn.click();
+  const m = page.locator(".modal").last();
+  await expect(m).toBeVisible({ timeout: 5_000 });
+  // Fill work name (first input)
+  await m.locator("input").first().fill(workName);
+  // Clear the date field (second input = affectDate) to avoid backend TypeError
+  const dateInput = m.locator("input[type=date]");
+  await dateInput.fill("");
+  // Save
+  await m.getByRole("button", { name: "保存", exact: true }).click();
+  await expect(m).not.toBeVisible({ timeout: 6_000 });
+  // Wait for the new work to appear in the sidebar. After the backend responds
+  // with the new work, mutation.onSuccess fires: setScreen("work") + setCurrentWG +
+  // setCurrentWork + invalidateQueries(works). The works query refetches and the
+  // sidebar shows the new work. We wait here for that to settle so that:
+  //  (a) the mutation onSuccess is complete (no more pending state transitions)
+  //  (b) gotoStationsTab won't race with the "setScreen('work')" call
+  //
+  // NOTE: The app has a useEffect that resets currentWork to null if the newly
+  // created work isn't in apiWorks yet (stale cache). We do NOT wait for the work
+  // screen / 新規列車 button here because of that race. Instead we just wait for
+  // the work to be visible in the sidebar (which confirms onSuccess + query refresh
+  // completed), and let callers use gotoWorkFromSidebar to navigate to the work.
+  await expect(
+    page.locator(".sidebar-item.indent").filter({ hasText: workName }).first()
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+/** Click the "🚉 駅（全体）" tab inside LineManager. */
+async function gotoStationsTab(page: import("@playwright/test").Page) {
+  await gotoLines(page);
+  // Wait for LineManager to fully mount and tab buttons to be stable.
+  // The "路線・駅管理" click triggers a React screen transition; the tab bar
+  // may re-render several times while TanStack Query fetches lines/stations.
+  // We use waitForSelector with 'visible' state (not just attached) so we
+  // don't click a detaching element.
+  const tabBtn = page.getByRole("button", { name: /駅（全体）/ });
+  await expect(tabBtn).toBeVisible({ timeout: 10_000 });
+  await tabBtn.click();
+  // Wait for the quick-add bar to be visible
+  await expect(
+    page.getByPlaceholder(/駅名を入力してEnter/)
+  ).toBeVisible({ timeout: 8_000 });
+}
+
+/**
+ * Add a station via the quick-add bar on the "駅（全体）" tab.
+ * Returns the station name.
+ */
+async function addStation(
+  page: import("@playwright/test").Page,
+  name: string
+) {
+  const input = page.getByPlaceholder(/駅名を入力してEnter/);
+  await input.fill(name);
+  await page.getByRole("button", { name: /^追加$/ }).click();
+  // confirm it appears in the table (exact match to avoid matching 'ST' and 'ST駅' both)
+  await expect(page.getByRole("cell", { name, exact: true }).first()).toBeVisible({
+    timeout: 8_000,
+  });
+}
+
+/**
+ * Navigate to the work browser for a given project/wg/work.
+ * Assumes we are already on the project list page (or will reload to get there).
+ * Use this ONLY after page.reload() or when you know you're at the project list.
+ */
+async function gotoWork(
+  page: import("@playwright/test").Page,
+  projectName: string,
+  wgName: string,
+  workName: string
+) {
+  // openProject clicks the project card from the project list
+  await openProject(page, projectName);
+  // After openProject, SidebarTree initializes openWG with all WG ids,
+  // so the WG should already be expanded. But click it if needed.
+  const workItem = page
+    .locator(".sidebar-item.indent")
+    .filter({ hasText: workName })
+    .first();
+  const workVisible = await workItem.isVisible({ timeout: 2_000 }).catch(() => false);
+  if (!workVisible) {
+    await page.locator(".sidebar-item").filter({ hasText: wgName }).first().click();
+    await expect(workItem).toBeVisible({ timeout: 10_000 });
+  }
+  // Click the work item
+  await workItem.click();
+  // Wait until the work content is visible (the train list panel header)
+  await expect(page.getByRole("button", { name: /新規列車/ }).first()).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+/**
+ * Navigate back to the work browser from WITHIN a project (after e.g. gotoStationsTab).
+ * Uses the sidebar directly (doesn't go back to project list).
+ * Strategy: wait up to 10s for the work item to appear (WG should already be expanded
+ * because createWork() expands it). If it still isn't visible, check whether the WG
+ * is expanded (▾) or collapsed (▸). Only click the WG if it shows ▸ (collapsed).
+ * This avoids accidentally COLLAPSING an already-expanded WG.
+ */
+async function gotoWorkFromSidebar(
+  page: import("@playwright/test").Page,
+  wgName: string,
+  workName: string
+) {
+  const workItem = page
+    .locator(".sidebar-item.indent")
+    .filter({ hasText: workName })
+    .first();
+
+  // Wait up to 10s for the work item to appear naturally
+  // (apiWorks refetch after createWork should settle within this window)
+  const isWorkVisible = await workItem.isVisible({ timeout: 10_000 }).catch(() => false);
+  if (!isWorkVisible) {
+    // Check if the WG button currently shows ▸ (collapsed) vs ▾ (expanded)
+    const wgItem = page.locator(".sidebar-item").filter({ hasText: wgName }).first();
+    const wgText = await wgItem.textContent().catch(() => "");
+    if (wgText?.includes("▸")) {
+      // WG is collapsed — expand it
+      await wgItem.click();
+    }
+    // If already ▾ (expanded), the work just hasn't loaded yet — wait more
+    await expect(workItem).toBeVisible({ timeout: 15_000 });
+  }
+  // Click the work
+  await workItem.click();
+  // Wait until the work content is visible (the train list panel header)
+  await expect(page.getByRole("button", { name: /新規列車/ }).first()).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+/**
+ * Create a train via ＋ 新規列車 button and click it in the list to select
+ * it (selects it in React state so the timetable grid mounts).
+ * Returns the trainNumber shown in the list ("0000M" by default).
+ */
+async function createAndSelectTrain(
+  page: import("@playwright/test").Page
+): Promise<string> {
+  // Click the top-right "＋ 新規列車" button in the train list panel. The new
+  // train (trainNumber "0000M") is auto-selected by WorkBrowser, which mounts
+  // the timetable grid — no manual click on the list entry is needed (the old
+  // `div ^0000M` click hit a non-clickable container and could hang).
+  await page.getByRole("button", { name: /新規列車/ }).first().click();
+  // The timetable grid should now be mounted (shows the "行を追加" button)
+  await expect(
+    page.getByRole("button", { name: /行を追加/ })
+  ).toBeVisible({ timeout: 10_000 });
+  return "0000M";
+}
+
+/**
+ * Full re-navigation after page.reload():
+ * Reload → project list appears → open project → sidebar → work → select train.
+ */
+async function reloadAndNavigate(
+  page: import("@playwright/test").Page,
+  projectName: string,
+  wgName: string,
+  workName: string,
+  // Train number to select after re-navigating. Defaults to "0000M" (the
+  // number createAndSelectTrain assigns). Tests that rename the train must
+  // pass the new number so this doesn't hang waiting for the old one.
+  trainNumber = "0000M"
+) {
+  // Inline edits fire their save mutation asynchronously; the UI signal the
+  // tests wait on (the edit input unmounting) happens BEFORE the PUT completes.
+  // Reloading immediately aborts the in-flight write (net::ERR_ABORTED), so the
+  // value never persists. Let pending requests settle before navigating away.
+  await page.waitForLoadState("networkidle");
+  await page.reload();
+  // After reload the app boots to the project list (no URL routing)
+  await expect(page.locator(".project-card").first()).toBeVisible({ timeout: 15_000 });
+  await gotoWork(page, projectName, wgName, workName);
+  // Select the train in the list by its number (default "0000M").
+  await page
+    .locator("div")
+    .filter({ hasText: trainNumber })
+    .first()
+    .click();
+  await expect(
+    page.getByRole("button", { name: /行を追加/ })
+  ).toBeVisible({ timeout: 10_000 });
+}
+
+/**
+ * Full test setup: project + WG + stations + work → navigate to work browser.
+ * Returns an object with the created entity names.
+ * Ends on the work browser screen with the "新規列車" button visible.
+ *
+ * Strategy: create everything, then use page.reload() to get a clean state,
+ * then navigate via the project list → sidebar. This avoids complex state
+ * management issues with React state and TanStack Query cache timing.
+ */
+async function setupProjectAndWork(
+  page: import("@playwright/test").Page,
+  stationNames: string[]
+): Promise<{ pName: string; wgName: string; workName: string }> {
+  const pName = uniqueName("ttg-p");
+  const wgName = uniqueName("ttg-wg");
+  const workName = uniqueName("ttg-w");
+
+  await createProject(page, pName);
+  await openProject(page, pName);
+
+  // Navigate to lines screen to avoid duplicate "新規WG" button in work empty-state
+  await gotoLines(page);
+  await createWorkGroup(page, wgName);
+  // localCreateWork clears affectDate to avoid backend TypeError (affect_date string vs ?DateTimeInterface)
+  await localCreateWork(page, wgName, workName);
+
+  // Add stations if needed
+  if (stationNames.length > 0) {
+    // Go to stations tab (gotoStationsTab calls gotoLines then clicks the tab)
+    await gotoStationsTab(page);
+    for (const stName of stationNames) {
+      await addStation(page, stName);
+    }
+  }
+
+  // Reload to get a clean React state, then navigate via project list
+  await page.reload();
+  await expect(page.locator(".project-card").first()).toBeVisible({ timeout: 15_000 });
+  await gotoWork(page, pName, wgName, workName);
+
+  return { pName, wgName, workName };
+}
+
+/** Click "行を追加", pick a station from the picker, wait for row to appear. */
+async function addRow(
+  page: import("@playwright/test").Page,
+  stationName: string
+) {
+  await page.getByRole("button", { name: /行を追加/ }).click();
+  // Station picker modal
+  await expect(page.locator(".modal").last()).toBeVisible({ timeout: 6_000 });
+  await page
+    .locator(".modal")
+    .last()
+    .getByRole("button", { name: stationName })
+    .click();
+  // Row appears in the grid
+  await expect(
+    page.locator(".station-name").filter({ hasText: stationName })
+  ).toBeVisible({ timeout: 8_000 });
+}
+
+/* ─── Tests ─────────────────────────────────────────────────────────────── */
+
+test.describe("TimetableGrid", () => {
+  // Each test creates a full project + WG + work + station + train + rows,
+  // then reloads to verify persistence. 90 s covers the full round-trip.
+  test.setTimeout(90_000);
+
+  /**
+   * Shared setup: project + wg + work + 2 stations are created once and
+   * reused by every test (each test creates its own train/rows to stay
+   * isolated from count assertions).
+   *
+   * Because Playwright serial workers reset page state (not DB state), and
+   * stations are project-scoped, we create them in a beforeAll.
+   */
+
+  /* ─── add row ─────────────────────────────────────────────────────────── */
+
+  test("add row via 行を追加 → persists across reload", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const stName = uniqueName("ST");
+    const { pName, wgName, workName } = await setupProjectAndWork(page, [stName]);
+    await createAndSelectTrain(page);
+
+    // Add a row
+    await addRow(page, stName);
+
+    // Persist check: reload and re-navigate
+    await reloadAndNavigate(page, pName, wgName, workName);
+    await expect(
+      page.locator(".station-name").filter({ hasText: stName })
+    ).toBeVisible({ timeout: 10_000 });
+
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── station picker populated from real API ───────────────────────────── */
+
+  test("station picker shows real API stations (not sample data)", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-api-p");
+    const wgName = uniqueName("ttgrid-api-wg");
+    const workName = uniqueName("ttgrid-api-w");
+    const stName = uniqueName("API_ST");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+
+    await gotoStationsTab(page);
+    await addStation(page, stName);
+
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+
+    // Open the station picker
+    await page.getByRole("button", { name: /行を追加/ }).click();
+    const pickerModal = page.locator(".modal").last();
+    await expect(pickerModal).toBeVisible({ timeout: 6_000 });
+
+    // The real station we created should appear
+    await expect(
+      pickerModal.getByRole("button", { name: stName })
+    ).toBeVisible({ timeout: 6_000 });
+
+    // Sample-data stations (hardcoded in sampleData.ts) should NOT appear
+    // because modelProjectStations comes from the API for THIS project
+    const sampleStation = pickerModal.getByRole("button", { name: /新大阪|品川/ });
+    await expect(sampleStation).not.toBeVisible();
+
+    // Close the picker
+    await pickerModal.getByRole("button", { name: /✕/ }).click();
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── arrive/depart inline edit → persists ─────────────────────────────── */
+
+  test("arrive time inline edit persists across reload", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-arr-p");
+    const wgName = uniqueName("ttgrid-arr-wg");
+    const workName = uniqueName("ttgrid-arr-w");
+    const stName = uniqueName("ARR_ST");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, stName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, stName);
+
+    // Click arrive time cell (first .time-display in the row for this station)
+    const stRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    await stRow.locator(".time-display").first().click();
+    // Input appears
+    const timeInput = stRow.locator(".time-input").first();
+    await expect(timeInput).toBeVisible({ timeout: 5_000 });
+    await timeInput.fill("08:30:00");
+    await timeInput.press("Tab");
+
+    // Wait for API mutation to complete (input detaches, grid re-renders)
+    await expect(stRow.locator(".time-input")).toHaveCount(0, { timeout: 8_000 });
+
+    // Reload and check it persisted
+    await reloadAndNavigate(page, pName, wgName, workName);
+    const reloadedRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    // The arrive time should show 08:30 somewhere in the row
+    await expect(reloadedRow).toContainText(/08.30/, { timeout: 8_000 });
+
+    expect(alerts).toHaveLength(0);
+  });
+
+  test("departure time inline edit persists across reload", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-dep-p");
+    const wgName = uniqueName("ttgrid-dep-wg");
+    const workName = uniqueName("ttgrid-dep-w");
+    const stName = uniqueName("DEP_ST");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, stName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, stName);
+
+    const stRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    // Departure cell is the second .time-display in the row
+    await stRow.locator(".time-display").nth(1).click();
+    const timeInput = stRow.locator(".time-input").first();
+    await expect(timeInput).toBeVisible({ timeout: 5_000 });
+    await timeInput.fill("09:15:00");
+    await timeInput.press("Tab");
+    await expect(stRow.locator(".time-input")).toHaveCount(0, { timeout: 8_000 });
+
+    await reloadAndNavigate(page, pName, wgName, workName);
+    const reloadedRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    await expect(reloadedRow).toContainText(/09.15/, { timeout: 8_000 });
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── 通過 (isPass) toggle ─────────────────────────────────────────────── */
+
+  test("通過 checkbox toggle persists across reload", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-pass-p");
+    const wgName = uniqueName("ttgrid-pass-wg");
+    const workName = uniqueName("ttgrid-pass-w");
+    const stName = uniqueName("PASS_ST");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, stName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, stName);
+
+    const stRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    const passCheck = stRow.locator(".toggle-check");
+    await expect(passCheck).not.toBeChecked();
+    // The checkbox is controlled by row.isPass with no optimistic update: after
+    // the click it re-renders from props (still false) until the PUT round-trips
+    // and the query refetches. Playwright's .check() expects a synchronous
+    // toggle and fails ("did not change its state"); click then await the
+    // eventual checked state instead.
+    await passCheck.click();
+    await expect(passCheck).toBeChecked({ timeout: 8_000 });
+
+    await reloadAndNavigate(page, pName, wgName, workName);
+    const reloadedRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    await expect(reloadedRow.locator(".toggle-check")).toBeChecked({ timeout: 8_000 });
+
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── remarks inline edit → persists ──────────────────────────────────── */
+
+  test("remarks inline edit persists across reload", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-rem-p");
+    const wgName = uniqueName("ttgrid-rem-wg");
+    const workName = uniqueName("ttgrid-rem-w");
+    const stName = uniqueName("REM_ST");
+    const remarkText = uniqueName("注意");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, stName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, stName);
+
+    const stRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    const remarksInput = stRow.locator(".remarks-input");
+    await remarksInput.fill(remarkText);
+    await remarksInput.blur();
+    await page.waitForTimeout(500);
+
+    await reloadAndNavigate(page, pName, wgName, workName);
+    const reloadedRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    await expect(reloadedRow.locator(".remarks-input")).toHaveValue(remarkText, {
+      timeout: 8_000,
+    });
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── row delete ──────────────────────────────────────────────────────── */
+
+  test("row delete button removes row and persists across reload", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-del-p");
+    const wgName = uniqueName("ttgrid-del-wg");
+    const workName = uniqueName("ttgrid-del-w");
+    const stName = uniqueName("DEL_ST");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, stName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, stName);
+
+    // Confirm row is present
+    await expect(
+      page.locator(".station-name").filter({ hasText: stName })
+    ).toBeVisible();
+
+    // Click the ✕ delete button in the row (no confirm dialog – direct mutation)
+    const stRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    await stRow.locator(".row-action-btn.del").click();
+
+    // Row disappears immediately
+    await expect(
+      page.locator(".station-name").filter({ hasText: stName })
+    ).not.toBeVisible({ timeout: 8_000 });
+
+    // Reload check
+    await reloadAndNavigate(page, pName, wgName, workName);
+    await expect(
+      page.locator(".station-name").filter({ hasText: stName })
+    ).not.toBeVisible({ timeout: 8_000 });
+
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── detail modal (⚙ button) ──────────────────────────────────────────── */
+
+  test("⚙ detail modal opens and saves drive time / remarks / isOperationOnlyStop", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-dtl-p");
+    const wgName = uniqueName("ttgrid-dtl-wg");
+    const workName = uniqueName("ttgrid-dtl-w");
+    const stName = uniqueName("DTL_ST");
+    const detailRemark = uniqueName("dtl-remark");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, stName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, stName);
+
+    // Open detail modal via the ⚙ button
+    const stRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    await stRow.getByRole("button", { name: /⚙/ }).click();
+
+    const detailModal = page.locator(".modal").last();
+    await expect(detailModal).toBeVisible({ timeout: 6_000 });
+
+    // Set drive time minutes to 5
+    const driveTimeMM = detailModal.locator("input[type=number]").first();
+    await driveTimeMM.fill("5");
+
+    // Toggle 運転停車 (isOperationOnlyStop). Select by its label, not by index:
+    // the modal's checkbox order varies with conditional fields (着/発 非表示,
+    // first/last-row extras), so nth(N) is unreliable and hit departureHidden.
+    const opStopCheck = detailModal
+      .locator("label")
+      .filter({ hasText: /運転停車/ })
+      .locator("input[type=checkbox]");
+    await opStopCheck.check();
+
+    // Set remarks in the detail modal (the BBCode-aware textarea area)
+    // The RowDetailModal uses BBCodeField for remarks
+    const remarksArea = detailModal.locator("textarea").last();
+    await remarksArea.fill(detailRemark);
+
+    // Save
+    await detailModal.getByRole("button", { name: /保存/ }).click();
+    await expect(detailModal).not.toBeVisible({ timeout: 6_000 });
+    await page.waitForTimeout(500);
+
+    // Reopen the detail modal to verify persisted values
+    await reloadAndNavigate(page, pName, wgName, workName);
+    const reloadedRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    await reloadedRow.getByRole("button", { name: /⚙/ }).click();
+    const reloadedModal = page.locator(".modal").last();
+    await expect(reloadedModal).toBeVisible({ timeout: 6_000 });
+
+    // Drive time minutes should be 5
+    await expect(reloadedModal.locator("input[type=number]").first()).toHaveValue("5", {
+      timeout: 6_000,
+    });
+    // 運転停車 should still be checked
+    await expect(
+      reloadedModal.locator("label").filter({ hasText: /運転停車/ }).locator("input[type=checkbox]")
+    ).toBeChecked({ timeout: 6_000 });
+    // Remarks
+    await expect(reloadedModal.locator("textarea").last()).toHaveValue(detailRemark, {
+      timeout: 6_000,
+    });
+
+    expect(alerts).toHaveLength(0);
+  });
+
+  test("detail modal double-click on station cell also opens it", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-dbl-p");
+    const wgName = uniqueName("ttgrid-dbl-wg");
+    const workName = uniqueName("ttgrid-dbl-w");
+    const stName = uniqueName("DBL_ST");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, stName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, stName);
+
+    // Double-click the station cell
+    const stRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    await stRow.locator(".station-cell").dblclick();
+    const detailModal = page.locator(".modal").last();
+    await expect(detailModal).toBeVisible({ timeout: 6_000 });
+
+    // Modal title should contain the station name
+    await expect(detailModal.locator(".modal-title")).toContainText(stName);
+
+    // Close
+    await detailModal.getByRole("button", { name: /✕/ }).click();
+    await expect(detailModal).not.toBeVisible({ timeout: 6_000 });
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── detail modal: hasBracket (first row only) ────────────────────────── */
+
+  test("detail modal shows 車両到着時刻 checkbox only for first row", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-bkt-p");
+    const wgName = uniqueName("ttgrid-bkt-wg");
+    const workName = uniqueName("ttgrid-bkt-w");
+    const st1Name = uniqueName("BKT_ST1");
+    const st2Name = uniqueName("BKT_ST2");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, st1Name);
+    await addStation(page, st2Name);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, st1Name);
+    await addRow(page, st2Name);
+
+    // First row detail: 車両到着時刻 should appear
+    const row1 = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: st1Name }),
+    });
+    await row1.getByRole("button", { name: /⚙/ }).click();
+    const modal1 = page.locator(".modal").last();
+    await expect(modal1.getByText(/車両到着時刻/)).toBeVisible({ timeout: 5_000 });
+    await modal1.getByRole("button", { name: /✕/ }).click();
+    await expect(modal1).not.toBeVisible({ timeout: 5_000 });
+
+    // Second row detail: 車両到着時刻 should NOT appear
+    const row2 = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: st2Name }),
+    });
+    await row2.getByRole("button", { name: /⚙/ }).click();
+    const modal2 = page.locator(".modal").last();
+    await expect(modal2).toBeVisible({ timeout: 5_000 });
+    await expect(modal2.getByText(/車両到着時刻/)).not.toBeVisible();
+    await modal2.getByRole("button", { name: /✕/ }).click();
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── detail modal: "終着駅にしない" (last row only) ───────────────────── */
+
+  test("detail modal shows 終着駅にしない checkbox only for last row", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-last-p");
+    const wgName = uniqueName("ttgrid-last-wg");
+    const workName = uniqueName("ttgrid-last-w");
+    const st1Name = uniqueName("LAST_ST1");
+    const st2Name = uniqueName("LAST_ST2");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, st1Name);
+    await addStation(page, st2Name);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, st1Name);
+    await addRow(page, st2Name);
+
+    // First row: no "終着駅にしない"
+    const row1 = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: st1Name }),
+    });
+    await row1.getByRole("button", { name: /⚙/ }).click();
+    const modal1 = page.locator(".modal").last();
+    await expect(modal1).toBeVisible({ timeout: 5_000 });
+    await expect(modal1.getByText(/終着駅にしない/)).not.toBeVisible();
+    await modal1.getByRole("button", { name: /✕/ }).click();
+    await expect(modal1).not.toBeVisible();
+
+    // Last row: "終着駅にしない" should appear
+    const row2 = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: st2Name }),
+    });
+    await row2.getByRole("button", { name: /⚙/ }).click();
+    const modal2 = page.locator(".modal").last();
+    await expect(modal2.getByText(/終着駅にしない/)).toBeVisible({ timeout: 5_000 });
+    await modal2.getByRole("button", { name: /✕/ }).click();
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── detail modal: runInLimit / runOutLimit ────────────────────────────── */
+
+  test("detail modal runInLimit/runOutLimit persist across reload", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-lim-p");
+    const wgName = uniqueName("ttgrid-lim-wg");
+    const workName = uniqueName("ttgrid-lim-w");
+    const stName = uniqueName("LIM_ST");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, stName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, stName);
+
+    const stRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    await stRow.getByRole("button", { name: /⚙/ }).click();
+    const detailModal = page.locator(".modal").last();
+    await expect(detailModal).toBeVisible({ timeout: 6_000 });
+
+    // runInLimit input: "進入制限" label, number input after it
+    const runInInput = detailModal.locator("input[type=number][min='0'][max='999']").first();
+    const runOutInput = detailModal.locator("input[type=number][min='0'][max='999']").nth(1);
+    await runInInput.fill("80");
+    await runOutInput.fill("100");
+
+    await detailModal.getByRole("button", { name: /保存/ }).click();
+    await expect(detailModal).not.toBeVisible({ timeout: 6_000 });
+    await page.waitForTimeout(500);
+
+    // Reload and recheck
+    await reloadAndNavigate(page, pName, wgName, workName);
+    const reloadedRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    await reloadedRow.getByRole("button", { name: /⚙/ }).click();
+    const reloadedModal = page.locator(".modal").last();
+    await expect(reloadedModal).toBeVisible({ timeout: 6_000 });
+    await expect(
+      reloadedModal.locator("input[type=number][min='0'][max='999']").first()
+    ).toHaveValue("80", { timeout: 6_000 });
+    await expect(
+      reloadedModal.locator("input[type=number][min='0'][max='999']").nth(1)
+    ).toHaveValue("100", { timeout: 6_000 });
+
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── detail modal: workType field ─────────────────────────────────────── */
+
+  test("detail modal workType is NOT persisted (work_type 実装準備中)", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-wt-p");
+    const wgName = uniqueName("ttgrid-wt-wg");
+    const workName = uniqueName("ttgrid-wt-w");
+    const stName = uniqueName("WT_ST");
+    const workTypeVal = "荷役";
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, stName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, stName);
+
+    const stRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    await stRow.getByRole("button", { name: /⚙/ }).click();
+    const detailModal = page.locator(".modal").last();
+    await expect(detailModal).toBeVisible({ timeout: 6_000 });
+
+    // workType is the only TEXT input with placeholder "—" (runIn/runOut
+    // limits also use placeholder "—" but are type=number) → exclude those.
+    const workTypeInput = detailModal.locator("input[placeholder='—']:not([type=number])");
+    await workTypeInput.fill(workTypeVal);
+    await detailModal.getByRole("button", { name: /保存/ }).click();
+    await expect(detailModal).not.toBeVisible({ timeout: 6_000 });
+    await page.waitForTimeout(500);
+
+    await reloadAndNavigate(page, pName, wgName, workName);
+    const reloadedRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    await reloadedRow.getByRole("button", { name: /⚙/ }).click();
+    const reloadedModal = page.locator(".modal").last();
+    await expect(reloadedModal).toBeVisible({ timeout: 6_000 });
+    // work_type is UNIMPLEMENTED by design (実装準備中): the DB column is a
+    // TINYINT UNSIGNED, the backend WorkAtStationType enum has only
+    // `case none = 0`, and the OpenAPI doc labels it '作業種別 (実装準備中)'.
+    // The frontend surfaces it as a free-text input but the value cannot
+    // persist (can't store "荷役" in a TINYINT enum). It is OMITTED from the
+    // write path (toApiTimetableRow) so it degrades gracefully and the row
+    // save still succeeds — exactly like the showHH/arriveHidden model-only
+    // fields. See UNIMPLEMENTED.md §3-3.
+    await expect(
+      reloadedModal.locator("input[placeholder='—']:not([type=number])")
+    ).toHaveValue("", { timeout: 6_000 });
+
+    // The save must succeed silently — no error alert (work_type is not sent),
+    // matching the other model-only fields.
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── detail modal: showHH (model-only → won't persist) ───────────────── */
+
+  test("detail modal showHH radio changes are NOT persisted (model-only field)", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-shh-p");
+    const wgName = uniqueName("ttgrid-shh-wg");
+    const workName = uniqueName("ttgrid-shh-w");
+    const stName = uniqueName("SHH_ST");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, stName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, stName);
+
+    const stRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    await stRow.getByRole("button", { name: /⚙/ }).click();
+    const detailModal = page.locator(".modal").last();
+    await expect(detailModal).toBeVisible({ timeout: 6_000 });
+
+    // Select "常に表示" (showHH=true) radio
+    await detailModal.locator("label", { hasText: /常に表示/ }).click();
+
+    await detailModal.getByRole("button", { name: /保存/ }).click();
+    await expect(detailModal).not.toBeVisible({ timeout: 6_000 });
+    await page.waitForTimeout(500);
+
+    // Reload: showHH should have reverted to "自動" because the field is
+    // not part of modelRowToEntityDraft (WRONG-SOURCE / not persisted)
+    await reloadAndNavigate(page, pName, wgName, workName);
+    const reloadedRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    await reloadedRow.getByRole("button", { name: /⚙/ }).click();
+    const reloadedModal = page.locator(".modal").last();
+    await expect(reloadedModal).toBeVisible({ timeout: 6_000 });
+
+    // "自動" should be selected (radio is checked), not "常に表示"
+    const autoRadio = reloadedModal.locator("input[type=radio][name=showHH]").first();
+    await expect(autoRadio).toBeChecked({ timeout: 6_000 });
+
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── detail modal: arriveHidden/departureHidden (model-only → won't persist) */
+
+  test("detail modal arriveHidden checkbox is NOT persisted (model-only field)", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-ah-p");
+    const wgName = uniqueName("ttgrid-ah-wg");
+    const workName = uniqueName("ttgrid-ah-w");
+    const stName = uniqueName("AH_ST");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, stName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, stName);
+
+    const stRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    await stRow.getByRole("button", { name: /⚙/ }).click();
+    const detailModal = page.locator(".modal").last();
+    await expect(detailModal).toBeVisible({ timeout: 6_000 });
+
+    // Check "非表示" for the arrive time (label: 非表示)
+    const arriveHiddenCheck = detailModal
+      .locator("label", { hasText: /非表示/ })
+      .first()
+      .locator("input[type=checkbox]");
+    await arriveHiddenCheck.check();
+    await expect(arriveHiddenCheck).toBeChecked();
+
+    await detailModal.getByRole("button", { name: /保存/ }).click();
+    await expect(detailModal).not.toBeVisible({ timeout: 6_000 });
+    await page.waitForTimeout(500);
+
+    // Reload: 非表示 should have reverted (field not in entity type)
+    await reloadAndNavigate(page, pName, wgName, workName);
+    const reloadedRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    await reloadedRow.getByRole("button", { name: /⚙/ }).click();
+    const reloadedModal = page.locator(".modal").last();
+    await expect(reloadedModal).toBeVisible({ timeout: 6_000 });
+
+    const reloadedArrHidden = reloadedModal
+      .locator("label", { hasText: /非表示/ })
+      .first()
+      .locator("input[type=checkbox]");
+    // Should be unchecked after reload (not persisted)
+    await expect(reloadedArrHidden).not.toBeChecked({ timeout: 6_000 });
+
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── row count summary ─────────────────────────────────────────────────── */
+
+  test("row count summary in add-row-bar updates correctly", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-cnt-p");
+    const wgName = uniqueName("ttgrid-cnt-wg");
+    const workName = uniqueName("ttgrid-cnt-w");
+    const st1Name = uniqueName("CNT_ST1");
+    const st2Name = uniqueName("CNT_ST2");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, st1Name);
+    await addStation(page, st2Name);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, st1Name);
+    await addRow(page, st2Name);
+
+    // The add-row-bar shows "N 駅 · 通過 M · 運停 P"
+    const bar = page.locator(".add-row-bar");
+    await expect(bar).toContainText(/2 駅/, { timeout: 6_000 });
+    await expect(bar).toContainText(/通過.*0/);
+
+    // Toggle one to pass. The 通過 checkbox is controlled (checked={!!row.isPass})
+    // and its onChange fires an async mutation with NO optimistic update, so
+    // React immediately re-renders the box to its prior state. Playwright's
+    // .check() over-asserts synchronous state change and fails. Use .click()
+    // (which doesn't assert synchronous state) then assert the OBSERVABLE
+    // outcome after the mutation settles + refetch: the summary count AND the
+    // checkbox reflecting isPass=true.
+    const row1 = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: st1Name }),
+    });
+    const toggle = row1.locator(".toggle-check");
+    await toggle.click();
+    await expect(bar).toContainText(/通過.*1/, { timeout: 8_000 });
+    await expect(toggle).toBeChecked({ timeout: 8_000 });
+
+    // Persist check: reload and confirm the pass state survived.
+    await reloadAndNavigate(page, pName, wgName, workName);
+    const reloadedRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: st1Name }),
+    });
+    await expect(reloadedRow.locator(".toggle-check")).toBeChecked({ timeout: 8_000 });
+    await expect(page.locator(".add-row-bar")).toContainText(/通過.*1/, { timeout: 8_000 });
+
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── drag reorder: UNIMPLEMENTED ──────────────────────────────────────── */
+
+  test("drag-reorder handle is not rendered (UNIMPLEMENTED)", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-drag-p");
+    const wgName = uniqueName("ttgrid-drag-wg");
+    const workName = uniqueName("ttgrid-drag-w");
+    const stName = uniqueName("DRAG_ST");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, stName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, stName);
+
+    // The .drag-handle CSS class exists but no element with that class is
+    // rendered in StationRow → confirm it's absent
+    await expect(page.locator(".drag-handle")).toHaveCount(0);
+
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── track cell (station track required) ──────────────────────────────── */
+
+  test("track cell shows enabled — button when station has no tracks (lazy fetch)", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-trk-p");
+    const wgName = uniqueName("ttgrid-trk-wg");
+    const workName = uniqueName("ttgrid-trk-w");
+    const stName = uniqueName("TRK_ST");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, stName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, stName);
+
+    // By design the track-pick button is ENABLED whenever a station is assigned
+    // (stationId !== ""). Tracks are fetched lazily only when the picker opens
+    // (useStationTracks(stationId, open && stationId !== "")) to avoid fanning
+    // out a per-row tracks query. With no tracks it shows "—" (title "なし").
+    const trackBtn = page
+      .locator("tr")
+      .filter({ has: page.locator(".station-name", { hasText: stName }) })
+      .locator(".track-pick");
+    await expect(trackBtn).toBeEnabled({ timeout: 5_000 });
+    await expect(trackBtn).toHaveText("—");
+    await expect(trackBtn).toHaveAttribute("title", "なし");
+
+    // Opening the picker reveals the empty-tracks state. The opened track
+    // select is autoFocused (:focus); the row's color cell also renders a
+    // select.color-select, so scope to the focused one. With no tracks it has
+    // exactly one option (the "— なし —" placeholder).
+    await trackBtn.click();
+    const trackSelect = page
+      .locator("tr")
+      .filter({ has: page.locator(".station-name", { hasText: stName }) })
+      .locator("select.color-select:focus");
+    await expect(trackSelect).toBeVisible({ timeout: 5_000 });
+    await expect(trackSelect.locator("option")).toHaveCount(1, { timeout: 5_000 });
+    await expect(trackSelect.locator("option")).toHaveText("— なし —");
+
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── color cell ────────────────────────────────────────────────────────── */
+
+  test("color cell select persists across reload", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-col-p");
+    const wgName = uniqueName("ttgrid-col-wg");
+    const workName = uniqueName("ttgrid-col-w");
+    const stName = uniqueName("COL_ST");
+    const colorName = uniqueName("COL");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+
+    // Create a color via the color manager. The add UI is an INLINE form
+    // (ColorManager renders it when editingId === "new"), not a .modal — target
+    // the form's name input (placeholder "赤 / Red ...") directly on the page.
+    await page.getByRole("button", { name: /色マーカー管理/ }).click();
+    await page.getByRole("button", { name: /色マーカーを追加/ }).click();
+    const colorNameInput = page.getByPlaceholder("赤 / Red ...");
+    await expect(colorNameInput).toBeVisible({ timeout: 6_000 });
+    await colorNameInput.fill(colorName);
+    await page.getByRole("button", { name: /保存/ }).click();
+    await expect(colorNameInput).not.toBeVisible({ timeout: 6_000 });
+    // Confirm color appeared in the list
+    await expect(page.getByText(colorName)).toBeVisible({ timeout: 8_000 });
+
+    // Now navigate to work
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoStationsTab(page);
+    await addStation(page, stName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+    await addRow(page, stName);
+
+    // Select the color from the color cell select
+    const stRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    const colorSelect = stRow.locator(".color-select");
+    await colorSelect.selectOption({ label: colorName });
+    await page.waitForTimeout(500);
+
+    // Reload and check
+    await reloadAndNavigate(page, pName, wgName, workName);
+    const reloadedRow = page.locator("tr").filter({
+      has: page.locator(".station-name", { hasText: stName }),
+    });
+    // Assert the selected option's label persisted. (colorName must be passed
+    // into the browser context — it's a Node-side variable, not in scope inside
+    // evaluate.) Poll until the refetched row re-selects the color.
+    await expect
+      .poll(
+        () =>
+          reloadedRow
+            .locator(".color-select")
+            .evaluate((el: HTMLSelectElement) => el.options[el.selectedIndex]?.text ?? ""),
+        { timeout: 8_000 }
+      )
+      .toBe(colorName);
+
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── TrainHeaderBar: 🧩 パターン適用 button ──────────────────────────── */
+
+  test("🧩 パターン適用 button opens ApplyPatternDialog", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-pat-p");
+    const wgName = uniqueName("ttgrid-pat-wg");
+    const workName = uniqueName("ttgrid-pat-w");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+
+    // Click the パターン適用 button in the train header bar
+    await page.getByRole("button", { name: /パターン適用/ }).click();
+
+    // ApplyPatternDialog should open. Assert the modal container plus its
+    // unambiguous title (.modal-title shows "🧩 停車パターンから列車を作成").
+    // The previous /停車パターン|パターン/ text match hit 6 elements
+    // (strict-mode violation); scope to the dialog title instead.
+    const patternModal = page.locator(".modal").last();
+    await expect(patternModal).toBeVisible({ timeout: 6_000 });
+    // The button on a selected train opens the dialog in edit mode, so the
+    // title reads "…列車を編集" (vs "…作成" when creating a new train).
+    await expect(
+      patternModal.locator(".modal-title")
+    ).toContainText(/停車パターンから列車を(作成|編集)/, { timeout: 6_000 });
+
+    // Close it (the dialog has both a ✕ header button and a キャンセル footer
+    // button → scope to the modal and take the first).
+    const closeBtn = patternModal
+      .getByRole("button", { name: /閉じる|✕|キャンセル/ })
+      .first();
+    if (await closeBtn.isVisible()) {
+      await closeBtn.click();
+    }
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── TrainHeaderBar: ⚙ 列車情報 button ────────────────────────────────── */
+
+  test("⚙ 列車情報 button opens TrainInfoDialog and saves trainNumber", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-ti-p");
+    const wgName = uniqueName("ttgrid-ti-wg");
+    const workName = uniqueName("ttgrid-ti-w");
+    const newTrainNum = uniqueName("T").slice(0, 8);
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+
+    // Click ⚙ 列車情報 button
+    await page.getByRole("button", { name: /列車情報/ }).click();
+    const infoModal = page.locator(".modal").last();
+    await expect(infoModal).toBeVisible({ timeout: 6_000 });
+
+    // Change the train number
+    const trainNumInput = infoModal.locator("input").first();
+    await trainNumInput.fill(newTrainNum);
+    await infoModal.getByRole("button", { name: /保存/ }).click();
+    await expect(infoModal).not.toBeVisible({ timeout: 6_000 });
+    await page.waitForTimeout(500);
+
+    // Reload and check. After the rename the train is no longer "0000M", so
+    // select it by its new number.
+    await reloadAndNavigate(page, pName, wgName, workName, newTrainNum);
+    // The new train number persisted and appears in BOTH the train list and
+    // the selected-train header bar (2 elements), so .first() avoids a
+    // strict-mode violation while still asserting the rename persisted.
+    await expect(page.getByText(newTrainNum).first()).toBeVisible({ timeout: 8_000 });
+
+    expect(alerts).toHaveLength(0);
+  });
+
+  /* ─── Picker: empty project shows proper message ────────────────────────── */
+
+  test("station picker shows 'no stations registered' when project has no stations", async ({ appPage: page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (d) => { alerts.push(d.message()); void d.accept(); });
+
+    const pName = uniqueName("ttgrid-empty-p");
+    const wgName = uniqueName("ttgrid-empty-wg");
+    const workName = uniqueName("ttgrid-empty-w");
+
+    await createProject(page, pName);
+    await openProject(page, pName);
+    await safeCreateWorkGroup(page, wgName);
+    await localCreateWork(page, wgName, workName);
+    await gotoWorkFromSidebar(page, wgName, workName);
+    await createAndSelectTrain(page);
+
+    // Open picker without any stations
+    await page.getByRole("button", { name: /行を追加/ }).click();
+    const pickerModal = page.locator(".modal").last();
+    await expect(pickerModal).toBeVisible({ timeout: 6_000 });
+
+    await expect(
+      pickerModal.getByText(/このプロジェクトには駅が登録されていません/)
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Close
+    await pickerModal.getByRole("button", { name: /✕/ }).click();
+    expect(alerts).toHaveLength(0);
+  });
+
+});

--- a/frontend/e2e/work.spec.ts
+++ b/frontend/e2e/work.spec.ts
@@ -1,0 +1,1047 @@
+/**
+ * E2E tests for the Work / Trains browser screen and the project sidebar.
+ *
+ * Setup per test: createProject → openProject → createWG (local) → createWork
+ * (uses shared helpers from helpers.ts except createWorkGroup — see below).
+ */
+import { test, expect, type Page } from "./fixtures";
+import {
+	createProject,
+	openProject,
+	uniqueName,
+	modal,
+	clickModalButton,
+} from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Local helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Local createWG that uses .first() to avoid strict-mode violations.
+ *
+ * When a project has no WGs yet, the main content pane shows an extra
+ * "＋ 新規WG" button (App.tsx:1513-1518). The shared helper (helpers.ts:82)
+ * does not use .first(), causing a strict-mode error.
+ */
+async function createWG(page: Page, name: string): Promise<void> {
+	await page.getByRole("button", { name: /新規WG/ }).first().click();
+	const m = modal(page);
+	await m.locator("input").first().fill(name);
+	await clickModalButton(page, "保存");
+	await expect(
+		page.locator(".sidebar-item").filter({ hasText: name })
+	).toBeVisible({ timeout: 10_000 });
+}
+
+/**
+ * Local createWork: clicks the WG row to OPEN it (WG always starts closed
+ * after createWG — SidebarTree initialises openWG from an empty workGroups
+ * set), then clicks the "＋ 新規ワーク" indent item.
+ *
+ * After the modal saves, App.tsx onSuccess sets currentWG + currentWork and
+ * the sidebar work item appears once apiWorks (TanStack Query) refreshes.
+ */
+async function localCreateWork(
+	page: Page,
+	wgName: string,
+	workName: string
+): Promise<void> {
+	// WG is closed after createWG — click it to open.
+	await page
+		.locator(".sidebar-item")
+		.filter({ hasText: wgName })
+		.first()
+		.click();
+	// Wait for the "新規ワーク" indent button to appear.
+	const newWorkBtn = page
+		.locator(".sidebar-item.indent")
+		.filter({ hasText: "新規ワーク" })
+		.first();
+	await expect(newWorkBtn).toBeVisible({ timeout: 5_000 });
+	await newWorkBtn.click();
+	// Wait explicitly for the WorkDialog modal to open.
+	await expect(page.locator(".modal-backdrop")).toBeVisible({ timeout: 5_000 });
+	const m = modal(page);
+	// Fill in the work name (first input in the dialog).
+	await m.locator("input").first().fill(workName);
+	// Clear the affect_date input (second input) to avoid a BACKEND-500 bug:
+	// POST /work_groups/{id}/works returns 500 when affect_date is a date string.
+	// Clearing the field sends affect_date=undefined in the request.
+	await m.locator("input[type='date']").first().fill("");
+	// Wait for the save button to be enabled (valid name entered).
+	const saveBtn = m.getByRole("button", { name: "保存", exact: true });
+	await expect(saveBtn).toBeEnabled({ timeout: 3_000 });
+	await saveBtn.click();
+	// Wait for the modal backdrop to close.
+	await expect(page.locator(".modal-backdrop")).not.toBeVisible({ timeout: 10_000 });
+}
+
+/**
+ * Navigate from the project list to the WorkBrowser for a specific work.
+ * Used post-reload (reload drops you back to the project list).
+ *
+ * After reload openProject re-runs, and SidebarTree initialises openWG from
+ * the CURRENT project.workGroups (which already contains the WG), so the WG
+ * starts OPEN and the work item is immediately visible.
+ */
+async function gotoWork(
+	page: Page,
+	projName: string,
+	wgName: string,
+	workName: string
+): Promise<void> {
+	await openProject(page, projName);
+	// WG should be open (initialised from existing workGroups on mount).
+	// Wait up to 5 s; if still not visible the WG might be closed, try opening it.
+	const workItem = page
+		.locator(".sidebar-item.indent")
+		.filter({ hasText: workName })
+		.first();
+	const wgItem = page.locator(".sidebar-item").filter({ hasText: wgName }).first();
+	try {
+		await expect(workItem).toBeVisible({ timeout: 5_000 });
+	} catch {
+		// Fallback: WG was closed — open it.
+		await wgItem.click();
+		await expect(workItem).toBeVisible({ timeout: 5_000 });
+	}
+	await workItem.click();
+	// Wait until the WorkBrowser train panel renders.
+	await expect(
+		page.getByRole("button", { name: /新規列車/ }).first()
+	).toBeVisible({ timeout: 10_000 });
+}
+
+/**
+ * Setup shortcut: project + WG + work, and navigate into the work screen.
+ * Returns { proj, wg, work } names for use in assertions.
+ *
+ * NOTE: createWork (helpers.ts) saves the modal and App.tsx onSuccess calls
+ * setCurrentWork/setScreen, but the work isn't rendered until apiWorks
+ * (TanStack Query) refreshes and the sidebar shows the work item. We wait for
+ * the work sidebar item to appear, then click it explicitly to ensure
+ * WorkBrowser renders.
+ */
+async function setupWorkScreen(page: Page) {
+	const proj = uniqueName("wk-proj");
+	const wg = uniqueName("wk-wg");
+	const work = uniqueName("wk-work");
+	await createProject(page, proj);
+	await openProject(page, proj);
+	await createWG(page, wg);
+	await localCreateWork(page, wg, work);
+
+	// Wait for the work item to appear in the sidebar (mutation + query refresh).
+	const workItem = page
+		.locator(".sidebar-item.indent")
+		.filter({ hasText: work })
+		.first();
+	await expect(workItem).toBeVisible({ timeout: 10_000 });
+
+	// Click it to ensure WorkBrowser renders.
+	await workItem.click();
+	await expect(
+		page.getByRole("button", { name: /新規列車/ }).first()
+	).toBeVisible({ timeout: 10_000 });
+	return { proj, wg, work };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Work / Train browser", () => {
+	// ── Sidebar: WG expand/collapse ─────────────────────────────────────────
+
+	test("sidebar WG row toggles expand/collapse", async ({ appPage: page }) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		const { wg, work } = await setupWorkScreen(page);
+
+		// Work item should be visible (WG is expanded).
+		const workItem = page
+			.locator(".sidebar-item.indent")
+			.filter({ hasText: work });
+		await expect(workItem.first()).toBeVisible();
+
+		// Click WG row to collapse.
+		const wgItem = page
+			.locator(".sidebar-item")
+			.filter({ hasText: wg })
+			.first();
+		await wgItem.click();
+		// After collapse, the work item should be hidden (display:none via React conditional).
+		await expect(workItem.first()).toBeHidden({ timeout: 5_000 });
+
+		// Click again to expand.
+		await wgItem.click();
+		await expect(workItem.first()).toBeVisible({ timeout: 5_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── Sidebar: "＋ 新規WG" button ─────────────────────────────────────────
+
+	test("sidebar '＋ 新規WG' creates and persists work group", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		const proj = uniqueName("wk-proj");
+		await createProject(page, proj);
+		await openProject(page, proj);
+
+		const wgName = uniqueName("new-wg");
+		// Use local createWG which uses .first() to avoid strict-mode.
+		await createWG(page, wgName);
+
+		// Should appear in sidebar immediately.
+		await expect(
+			page.locator(".sidebar-item").filter({ hasText: wgName }).first()
+		).toBeVisible({ timeout: 10_000 });
+
+		// Persists across reload.
+		await page.reload();
+		await openProject(page, proj);
+		await expect(
+			page.locator(".sidebar-item").filter({ hasText: wgName }).first()
+		).toBeVisible({ timeout: 10_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── Sidebar: "＋ 新規ワーク" inline button ─────────────────────────────
+
+	test("sidebar '＋ 新規ワーク' (inline) creates and persists work", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		const proj = uniqueName("wk-proj");
+		const wg = uniqueName("wk-wg");
+		await createProject(page, proj);
+		await openProject(page, proj);
+		await createWG(page, wg);
+
+		const workName = uniqueName("new-work");
+		// WG starts closed after creation — click to open it first.
+		await page
+			.locator(".sidebar-item")
+			.filter({ hasText: wg })
+			.first()
+			.click();
+		// Now the "＋ 新規ワーク" indent button is visible.
+		await page
+			.locator(".sidebar-item.indent")
+			.filter({ hasText: "新規ワーク" })
+			.first()
+			.click();
+		// Wait for modal to open before interacting.
+		await expect(page.locator(".modal-backdrop")).toBeVisible({ timeout: 5_000 });
+		const m = modal(page);
+		await m.locator("input").first().fill(workName);
+		// Clear affect_date to avoid BACKEND-500 (work creation fails with any date string).
+		await m.locator("input[type='date']").first().fill("");
+		const saveBtnInline = m.getByRole("button", { name: "保存", exact: true });
+		await expect(saveBtnInline).toBeEnabled({ timeout: 3_000 });
+		await saveBtnInline.click();
+		// Wait for modal to close before checking sidebar.
+		await expect(page.locator(".modal-backdrop")).not.toBeVisible({ timeout: 10_000 });
+
+		// Work should appear in the sidebar.
+		await expect(
+			page.locator(".sidebar-item.indent").filter({ hasText: workName }).first()
+		).toBeVisible({ timeout: 10_000 });
+
+		// Persists across reload.
+		await page.reload();
+		await openProject(page, proj);
+		// Expand WG.
+		const wgItem = page
+			.locator(".sidebar-item")
+			.filter({ hasText: wg })
+			.first();
+		if (
+			!(await page
+				.locator(".sidebar-item.indent")
+				.filter({ hasText: workName })
+				.first()
+				.isVisible())
+		) {
+			await wgItem.click();
+		}
+		await expect(
+			page.locator(".sidebar-item.indent").filter({ hasText: workName }).first()
+		).toBeVisible({ timeout: 10_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── Sidebar: Work row click selects work ────────────────────────────────
+
+	test("clicking Work row in sidebar navigates to WorkBrowser", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		await setupWorkScreen(page);
+
+		// WorkBrowser is already visible after setupWorkScreen.
+		// Verify the 新規列車 button is present (confirms WorkBrowser rendered).
+		await expect(
+			page.getByRole("button", { name: /新規列車/ }).first()
+		).toBeVisible({ timeout: 10_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── Sidebar: WG right-click → 編集 ────────────────────────────────────
+
+	test("WG right-click context menu → 編集 updates WG name and persists", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		const { proj, wg } = await setupWorkScreen(page);
+
+		const wgItem = page
+			.locator(".sidebar-item")
+			.filter({ hasText: wg })
+			.first();
+		await wgItem.click({ button: "right" });
+
+		// Wait for the context menu to appear.
+		// ContextMenu (EntityDialogs.tsx) renders as a fixed-position div at zIndex 200.
+		// Its items are <button> elements with icon+label spans.
+		// We wait for "編集" to appear outside any .modal, then click it.
+		const ctxEditBtn = page
+			.locator("button")
+			.filter({ hasText: /編集/ })
+			.first();
+		await expect(ctxEditBtn).toBeVisible({ timeout: 5_000 });
+		await ctxEditBtn.click();
+
+		const newName = uniqueName("wg-edited");
+		const m = modal(page);
+		const nameInput = m.locator("input").first();
+		await nameInput.selectText();
+		await nameInput.fill(newName);
+		await clickModalButton(page, "保存");
+
+		await expect(
+			page.locator(".sidebar-item").filter({ hasText: newName }).first()
+		).toBeVisible({ timeout: 10_000 });
+
+		// Persists across reload.
+		await page.reload();
+		await openProject(page, proj);
+		await expect(
+			page.locator(".sidebar-item").filter({ hasText: newName }).first()
+		).toBeVisible({ timeout: 10_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── Sidebar: WG right-click → ＋新規ワーク ────────────────────────────
+
+	test("WG right-click context menu → ＋新規ワーク creates work", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		const { wg } = await setupWorkScreen(page);
+
+		const wgItem = page
+			.locator(".sidebar-item")
+			.filter({ hasText: wg })
+			.first();
+		await wgItem.click({ button: "right" });
+
+		// Context menu "新規ワーク" — wait for it to appear.
+		// Note: the sidebar also has "新規ワーク" inline, but it uses .sidebar-item.indent,
+		// whereas the context menu button does not.
+		// The context menu item is a <button> that is NOT itself a .sidebar-item
+		// (the sidebar's inline "＋ 新規ワーク" is .sidebar-item.indent). Use a CSS
+		// :not on the element itself — a `hasNot` locator filter only excludes
+		// DESCENDANT matches, so it wouldn't exclude the sidebar button.
+		const ctxNewWork = page
+			.locator("button:not(.sidebar-item)")
+			.filter({ hasText: /新規ワーク/ })
+			.first();
+		await expect(ctxNewWork).toBeVisible({ timeout: 5_000 });
+		await ctxNewWork.click();
+
+		const workName = uniqueName("ctx-work");
+		const m = modal(page);
+		await m.locator("input").first().fill(workName);
+		// Clear affect_date to avoid BACKEND-500 (work creation fails with any date string).
+		await m.locator("input[type='date']").first().fill("");
+		await clickModalButton(page, "保存");
+
+		await expect(
+			page.locator(".sidebar-item.indent").filter({ hasText: workName }).first()
+		).toBeVisible({ timeout: 10_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── Sidebar: WG right-click → 削除 ───────────────────────────────────
+
+	test("WG right-click context menu → 削除 removes WG and persists", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		const { proj, wg } = await setupWorkScreen(page);
+
+		const wgItem = page
+			.locator(".sidebar-item")
+			.filter({ hasText: wg })
+			.first();
+		await wgItem.click({ button: "right" });
+
+		await page
+			.locator("button")
+			.filter({ hasText: /削除/ })
+			.first()
+			.click();
+
+		// ConfirmDialog (custom modal with a "削除" button).
+		await modal(page).getByRole("button", { name: "削除", exact: true }).click();
+
+		// WG should vanish.
+		await expect(
+			page.locator(".sidebar-item").filter({ hasText: wg })
+		).not.toBeVisible({ timeout: 10_000 });
+
+		// Persists across reload.
+		await page.reload();
+		await openProject(page, proj);
+		await expect(
+			page.locator(".sidebar-item").filter({ hasText: wg })
+		).not.toBeVisible();
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── Sidebar: Work right-click → 編集 ──────────────────────────────────
+
+	test("Work right-click context menu → 編集 updates work name and persists", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		const { proj, wg, work } = await setupWorkScreen(page);
+
+		const workItem = page
+			.locator(".sidebar-item.indent")
+			.filter({ hasText: work })
+			.first();
+		await workItem.click({ button: "right" });
+
+		await page
+			.locator("button")
+			.filter({ hasText: /編集/ })
+			.first()
+			.click();
+
+		const updatedName = uniqueName("work-edited");
+		const m = modal(page);
+		const nameInput = m.locator("input").first();
+		await nameInput.selectText();
+		await nameInput.fill(updatedName);
+		await clickModalButton(page, "保存");
+
+		await expect(
+			page
+				.locator(".sidebar-item.indent")
+				.filter({ hasText: updatedName })
+				.first()
+		).toBeVisible({ timeout: 10_000 });
+
+		// Persists across reload.
+		await page.reload();
+		await openProject(page, proj);
+		const wgItem = page
+			.locator(".sidebar-item")
+			.filter({ hasText: wg })
+			.first();
+		if (
+			!(await page
+				.locator(".sidebar-item.indent")
+				.filter({ hasText: updatedName })
+				.first()
+				.isVisible())
+		) {
+			await wgItem.click();
+		}
+		await expect(
+			page
+				.locator(".sidebar-item.indent")
+				.filter({ hasText: updatedName })
+				.first()
+		).toBeVisible({ timeout: 10_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── Sidebar: Work right-click → 削除 ─────────────────────────────────
+
+	test("Work right-click context menu → 削除 removes work and persists", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		const { proj, wg, work } = await setupWorkScreen(page);
+
+		const workItem = page
+			.locator(".sidebar-item.indent")
+			.filter({ hasText: work })
+			.first();
+		await workItem.click({ button: "right" });
+
+		await page
+			.locator("button")
+			.filter({ hasText: /削除/ })
+			.first()
+			.click();
+
+		// ConfirmDialog modal → 削除 button.
+		await modal(page).getByRole("button", { name: "削除", exact: true }).click();
+
+		await expect(
+			page.locator(".sidebar-item.indent").filter({ hasText: work })
+		).not.toBeVisible({ timeout: 10_000 });
+
+		await page.reload();
+		await openProject(page, proj);
+		const wgItem = page
+			.locator(".sidebar-item")
+			.filter({ hasText: wg })
+			.first();
+		if (!(await wgItem.isVisible())) {
+			// WG itself is gone somehow — test passed
+		} else {
+			// Expand WG if collapsed.
+			const isExpanded = await page
+				.locator(".sidebar-item.indent")
+				.filter({ hasText: "新規ワーク" })
+				.first()
+				.isVisible();
+			if (!isExpanded) await wgItem.click();
+			await expect(
+				page.locator(".sidebar-item.indent").filter({ hasText: work })
+			).not.toBeVisible();
+		}
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── Sidebar footer: 🛤 路線・駅管理 ────────────────────────────────────
+
+	test("sidebar footer '🛤 路線・駅管理' navigates to line manager", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		await setupWorkScreen(page);
+
+		// Use force:true to bypass the firebase emulator warning banner overlay.
+		await page
+			.getByRole("button", { name: /路線・駅管理/ })
+			.click({ force: true });
+		// LineManager screen renders "路線を追加" affordance.
+		await expect(
+			page.getByRole("button", { name: /路線を追加/ })
+		).toBeVisible({ timeout: 10_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── Sidebar footer: 🎨 色マーカー管理 ─────────────────────────────────
+
+	test("sidebar footer '🎨 色マーカー管理' navigates to color manager", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		await setupWorkScreen(page);
+
+		await page
+			.getByRole("button", { name: /色マーカー管理/ })
+			.click({ force: true });
+		// ColorManager renders "色マーカーを追加".
+		await expect(
+			page.getByRole("button", { name: /色マーカーを追加/ })
+		).toBeVisible({ timeout: 10_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── Sidebar footer: 📤 エクスポート (JSON) ────────────────────────────
+	// exportAll reads apiProjects and exports each via the backend graph API, so
+	// a download is produced. (Was WRONG-SOURCE: read in-memory sample `data` and
+	// returned early when the API projectId didn't match — fixed in App.tsx.)
+
+	test("sidebar footer '📤 エクスポート (JSON)' triggers download", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		await setupWorkScreen(page);
+
+		// Listen for a download event. Export should produce a file.
+		// (exportAll now reads apiProjects and exports each via the backend graph
+		// API, so a download is produced — previously it read in-memory sample
+		// data and returned early.)
+		const downloadPromise = page
+			.waitForEvent("download", { timeout: 3_000 })
+			.catch(() => null);
+
+		await page
+			.getByRole("button", { name: /エクスポート/ })
+			.click({ force: true });
+
+		const download = await downloadPromise;
+
+		// A download should happen (exportAll reads apiProjects → backend export).
+		expect(download, "📤 Export should produce a download file").not.toBeNull();
+	});
+
+	// ── WorkBrowser: "新規列車" creates a train immediately (no dialog) ────
+
+	test("'新規列車' button creates train immediately and it appears in list", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		await setupWorkScreen(page);
+
+		// Immediate create — no dialog. Default trainNumber is "0000M".
+		await page.getByRole("button", { name: /新規列車/ }).first().click();
+
+		// The train should appear in the train list panel.
+		await expect(page.locator("text=0000M").first()).toBeVisible({
+			timeout: 10_000,
+		});
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── WorkBrowser: train create → edit via ⚙ 列車情報 → persists ────────
+
+	test("create train → edit trainNumber via ⚙ 列車情報 → persists across reload", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		const { proj, wg, work } = await setupWorkScreen(page);
+
+		// Create a new train (immediate create).
+		await page.getByRole("button", { name: /新規列車/ }).first().click();
+
+		// Click the train row to select it.
+		const trainRow = page.locator("text=0000M").first();
+		await expect(trainRow).toBeVisible({ timeout: 10_000 });
+		await trainRow.click();
+
+		// TrainHeaderBar renders — open 列車情報 dialog.
+		await page.getByRole("button", { name: /列車情報/ }).first().click();
+
+		const dlg = modal(page);
+		await expect(dlg).toBeVisible({ timeout: 5_000 });
+
+		// Edit trainNumber to a unique value.
+		const uniqueTrainNum = uniqueName("T");
+		const numInput = dlg.locator("input").first();
+		await numInput.fill(uniqueTrainNum);
+
+		// Save.
+		await dlg.getByRole("button", { name: /保存/ }).click();
+
+		// Updated number should appear in the train list.
+		await expect(page.locator(`text=${uniqueTrainNum}`).first()).toBeVisible({
+			timeout: 10_000,
+		});
+
+		// Reload and verify persistence.
+		await page.reload();
+		await gotoWork(page, proj, wg, work);
+
+		await expect(page.locator(`text=${uniqueTrainNum}`).first()).toBeVisible({
+			timeout: 10_000,
+		});
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── WorkBrowser: train delete ────────────────────────────────────────
+
+	test("delete train via ⚙ dialog → train is gone after reload", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		// Train delete uses native confirm() — auto-accept via dialog handler.
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		const { proj, wg, work } = await setupWorkScreen(page);
+
+		// Create train and edit to unique name.
+		await page.getByRole("button", { name: /新規列車/ }).first().click();
+		await page.locator("text=0000M").first().click();
+
+		await page.getByRole("button", { name: /列車情報/ }).first().click();
+		const dlg = modal(page);
+		const uniqueTrainNum = uniqueName("DEL");
+		await dlg.locator("input").first().fill(uniqueTrainNum);
+		await dlg.getByRole("button", { name: /保存/ }).click();
+
+		// Select the train.
+		await page.locator(`text=${uniqueTrainNum}`).first().click();
+
+		// Re-open info dialog.
+		await page.getByRole("button", { name: /列車情報/ }).first().click();
+
+		// Click the 🗑 削除 button (triggers native confirm).
+		const dlg2 = modal(page);
+		await dlg2.getByRole("button", { name: /削除/ }).first().click();
+
+		// Native confirm is auto-accepted — train should disappear from BOTH the
+		// train list AND the selected-train header bar. The number renders in
+		// those two places, so while the delete settles the locator transiently
+		// matches 2 elements; `.not.toBeVisible()` strict-fails on 2 matches.
+		// `toHaveCount(0)` is the correct (and stronger) "all instances gone"
+		// assertion — it retries until ZERO elements match.
+		await expect(
+			page.locator(`text=${uniqueTrainNum}`)
+		).toHaveCount(0, { timeout: 10_000 });
+
+		// Reload and verify.
+		await page.reload();
+		await gotoWork(page, proj, wg, work);
+		await expect(page.locator(`text=${uniqueTrainNum}`)).toHaveCount(0, {
+			timeout: 10_000,
+		});
+
+		// The delete confirm dialog message should have been fired.
+		expect(alerts.some((a) => a.includes("削除しますか"))).toBe(true);
+	});
+
+	// ── WorkBrowser: train select ────────────────────────────────────────
+
+	test("clicking a train row selects it (header bar appears)", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		await setupWorkScreen(page);
+
+		// Create a train.
+		await page.getByRole("button", { name: /新規列車/ }).first().click();
+		const trainRow = page.locator("text=0000M").first();
+		await expect(trainRow).toBeVisible({ timeout: 10_000 });
+
+		// Click it — the TrainHeaderBar should render (⚙ 列車情報 button).
+		await trainRow.click();
+		await expect(
+			page.getByRole("button", { name: /列車情報/ }).first()
+		).toBeVisible({ timeout: 5_000 });
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── WorkBrowser: "🧩" (TrainListPanel header) opens ApplyPatternDialog ─
+
+	test("'🧩' button in train list panel header opens ApplyPatternDialog", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		await setupWorkScreen(page);
+
+		// The 🧩 button (btn-ghost btn-xs, title="停車パターンから追加").
+		await page.getByRole("button", { name: "🧩" }).first().click();
+
+		// ApplyPatternDialog renders — modal-title contains "停車パターンから列車を".
+		await expect(
+			page
+				.locator(".modal-title")
+				.filter({ hasText: "停車パターンから列車を" })
+				.first()
+		).toBeVisible({ timeout: 5_000 });
+
+		// Close.
+		await page
+			.locator(".modal")
+			.last()
+			.getByRole("button", { name: /キャンセル/ })
+			.click();
+		await expect(
+			page.locator(".modal-title").filter({ hasText: "停車パターンから列車を" })
+		).not.toBeVisible();
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── WorkBrowser: empty state "🧩 パターンから作成" button ──────────────
+
+	test("empty state '🧩 パターンから作成' opens ApplyPatternDialog", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		await setupWorkScreen(page);
+
+		// No train selected — the empty-state right pane shows "パターンから作成".
+		const patternBtn = page.getByRole("button", { name: /パターンから作成/ });
+		await expect(patternBtn).toBeVisible({ timeout: 5_000 });
+		await patternBtn.click();
+
+		await expect(
+			page
+				.locator(".modal-title")
+				.filter({ hasText: "停車パターンから列車を" })
+				.first()
+		).toBeVisible({ timeout: 5_000 });
+
+		await page
+			.locator(".modal")
+			.last()
+			.getByRole("button", { name: /キャンセル/ })
+			.click();
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── WorkBrowser: "🧩 パターン適用" in TrainHeaderBar ───────────────────
+
+	test("TrainHeaderBar '🧩 パターン適用' opens ApplyPatternDialog (existingTrain set)", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		await setupWorkScreen(page);
+
+		// Create and select a train.
+		await page.getByRole("button", { name: /新規列車/ }).first().click();
+		await page.locator("text=0000M").first().click();
+
+		await expect(
+			page.getByRole("button", { name: /パターン適用/ })
+		).toBeVisible({ timeout: 5_000 });
+		await page.getByRole("button", { name: /パターン適用/ }).click();
+
+		// Dialog opens with existingTrain → title says "列車を編集".
+		await expect(
+			page
+				.locator(".modal-title")
+				.filter({ hasText: "停車パターンから列車を" })
+				.first()
+		).toBeVisible({ timeout: 5_000 });
+
+		await page
+			.locator(".modal")
+			.last()
+			.getByRole("button", { name: /キャンセル/ })
+			.click();
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── ApplyPatternDialog: lines dropdown must NOT show sample data ──
+	// The dialog now receives modelLines (from the API), not the in-memory
+	// sample data.lines. Our freshly created test project has no lines, so the
+	// dropdown must not show the old sample lines "東海道本線"/"横須賀線" (ids l1/l2).
+
+	test("ApplyPatternDialog line filter does NOT show sample data lines", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		await setupWorkScreen(page);
+
+		// Open ApplyPatternDialog via the 🧩 button.
+		await page.getByRole("button", { name: "🧩" }).first().click();
+		await expect(
+			page
+				.locator(".modal-title")
+				.filter({ hasText: "停車パターンから列車を" })
+				.first()
+		).toBeVisible({ timeout: 5_000 });
+
+		// The line filter <select> is inside the modal.
+		const lineSelect = page.locator(".modal select").first();
+		const options = await lineSelect.locator("option").allTextContents();
+
+		// Sample-data lines that should NOT appear for a freshly created project.
+		const hasSampleLines =
+			options.some((o) => o.includes("東海道本線")) ||
+			options.some((o) => o.includes("横須賀線"));
+
+		// Close before asserting.
+		await page
+			.locator(".modal")
+			.last()
+			.getByRole("button", { name: /キャンセル/ })
+			.click();
+
+		// No sample lines visible (App.tsx now passes modelLines from the API,
+		// not the in-memory sample data.lines).
+		expect(
+			hasSampleLines,
+			"ApplyPatternDialog line dropdown should NOT show in-memory sample lines"
+		).toBe(false);
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── WorkBrowser: ⚙ TrainInfoDialog field edits (direction, destination) ─
+
+	test("TrainInfoDialog fields (direction, destination) are editable and saved", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		await setupWorkScreen(page);
+
+		await page.getByRole("button", { name: /新規列車/ }).first().click();
+		await page.locator("text=0000M").first().click();
+		await page.getByRole("button", { name: /列車情報/ }).first().click();
+
+		const dlg = modal(page);
+
+		// Change direction to 上り (↑). selectOption's `label` takes a string, not
+		// a regex; use the option value (-1 = 上り) instead.
+		const dirSelect = dlg.locator("select").first();
+		await dirSelect.selectOption("-1");
+
+		// Set destination (3rd input: trainNumber=0, direction select (not input), destination=1).
+		const dest = uniqueName("Dest");
+		await dlg.locator("input").nth(1).fill(dest);
+
+		// Save.
+		await dlg.getByRole("button", { name: /保存/ }).click();
+
+		// The TrainHeaderBar chip should now be amber (上り direction).
+		await expect(page.locator(".chip.amber").first()).toBeVisible({
+			timeout: 5_000,
+		});
+
+		expect(alerts).toHaveLength(0);
+	});
+
+	// ── WorkBrowser: ⚙ TrainInfoDialog cancel discards changes ──────────
+
+	test("TrainInfoDialog cancel does not apply changes", async ({
+		appPage: page,
+	}) => {
+		const alerts: string[] = [];
+		page.on("dialog", (d) => {
+			alerts.push(d.message());
+			void d.accept();
+		});
+
+		await setupWorkScreen(page);
+
+		await page.getByRole("button", { name: /新規列車/ }).first().click();
+		await page.locator("text=0000M").first().click();
+		await page.getByRole("button", { name: /列車情報/ }).first().click();
+
+		const dlg = modal(page);
+		const neverPersisted = uniqueName("NOPE");
+		await dlg.locator("input").first().fill(neverPersisted);
+
+		// Cancel.
+		await dlg.getByRole("button", { name: /キャンセル/ }).click();
+
+		// Original "0000M" should still be shown.
+		await expect(page.locator("text=0000M").first()).toBeVisible();
+		await expect(page.locator(`text=${neverPersisted}`)).not.toBeVisible();
+
+		expect(alerts).toHaveLength(0);
+	});
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
 		"redux-thunk": "^3.1.0"
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.60.0",
 		"@tsconfig/strictest": "^2.0.2",
 		"@types/react": "^18.2.43",
 		"@types/react-dom": "^18.2.17",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// E2E config. Targets the Vite dev server on localhost:5173, which proxies
+// /api → http://localhost:8080 (dockerized php backend) and lets the app's
+// `hostname === "localhost"` check wire Firebase Auth to the emulator (:9099).
+//
+// Prereqs (not started by Playwright): the docker backend stack must be up —
+//   docker compose up -d php mysql firebase
+// The Firebase Auth emulator is seeded with a@a.test / b@a.test (password 0000).
+//
+// This config lives outside the `tsc` build gate (tsconfig only includes src/)
+// and outside ESLint (ignored), so e2e specs never block the merge gate.
+export default defineConfig({
+	testDir: "./e2e",
+	globalSetup: "./e2e/global-setup.ts",
+	// Delete the dedicated E2E users' projects after the run so the shared dev DB
+	// never accumulates test artifacts (which slow the project-list render and
+	// flake the createProject setup helper). See e2e/global-teardown.ts.
+	globalTeardown: "./e2e/global-teardown.ts",
+	// DB/emulator state is shared across specs; run serially to avoid
+	// cross-spec collisions on created entities.
+	fullyParallel: false,
+	workers: 1,
+	forbidOnly: !!process.env["CI"],
+	retries: 0,
+	reporter: [["list"], ["html", { open: "never", outputFolder: "e2e-report" }]],
+	timeout: 30_000,
+	expect: { timeout: 7_000 },
+	use: {
+		baseURL: "http://localhost:5173",
+		trace: "retain-on-failure",
+		screenshot: "only-on-failure",
+		video: "retain-on-failure",
+	},
+	projects: [
+		{ name: "chromium", use: { ...devices["Desktop Chrome"] } },
+	],
+	webServer: {
+		command: "yarn dev",
+		url: "http://localhost:5173",
+		reuseExistingServer: true,
+		timeout: 30_000,
+	},
+});

--- a/frontend/src/api/adapters.ts
+++ b/frontend/src/api/adapters.ts
@@ -18,6 +18,11 @@ import type { components } from "./schema";
 
 import type { Color, Line, Project, ProjectStation, StationOnLine, StationTrack, StopPattern, StopPatternRow, TimetableRow, Train, Work, WorkGroup } from "../types/entities";
 
+// MySQL tinyint(1) booleans arrive as 0/1 (the schema types them boolean).
+// Coerce to a real boolean, preserving undefined for absent fields.
+const toBool = (v: boolean | number | undefined): boolean | undefined =>
+	v === undefined ? undefined : Boolean(v);
+
 // `affect_date` is an OpenAPI `format: date` (a calendar date, no time/zone) —
 // unlike `created_at` etc. which are `date-time`. Round-trip it via LOCAL date
 // parts so the day the user picked is preserved regardless of timezone.
@@ -240,7 +245,7 @@ export const fromApiTrain = (api: ApiTrain): Train => ({
 	beforeDeparture: api.before_departure,
 	afterArrive: api.after_arrive,
 	trainInfo: api.train_info,
-	isRideOnMoving: api.is_ride_on_moving,
+	isRideOnMoving: toBool(api.is_ride_on_moving),
 	createdAt: api.created_at !== undefined ? new Date(api.created_at) : undefined,
 });
 
@@ -284,10 +289,14 @@ export const fromApiTimetableRow = (api: ApiTimetableRow): TimetableRow => ({
 	description: api.description,
 	driveTimeMm: api.drive_time_mm,
 	driveTimeSs: api.drive_time_ss,
-	isOperationOnlyStop: api.is_operation_only_stop,
-	isPass: api.is_pass,
-	hasBracket: api.has_bracket,
-	isLastStop: api.is_last_stop,
+	// MySQL tinyint(1) comes back over the wire as 0/1 (not JSON true/false),
+	// even though the schema types them as boolean. Coerce to real booleans so
+	// round-tripping an edit doesn't re-send 0/1 — the backend's BoolValidationRule
+	// rejects non-bool with HTTP 400. Preserve undefined for absent fields.
+	isOperationOnlyStop: toBool(api.is_operation_only_stop),
+	isPass: toBool(api.is_pass),
+	hasBracket: toBool(api.has_bracket),
+	isLastStop: toBool(api.is_last_stop),
 	arriveTimeHh: api.arrive_time_hh,
 	arriveTimeMm: api.arrive_time_mm,
 	arriveTimeSs: api.arrive_time_ss,
@@ -311,7 +320,10 @@ export const toApiTimetableRow = (
 	stations_id: x.stationId,
 	station_tracks_id: x.stationTrackId,
 	colors_id_marker: x.colorIdMarker,
-	description: x.description,
+	// description is required (non-null) by the backend. Newly-constructed rows
+	// (e.g. the 行を追加 picker, apply-pattern) don't set it, so default to "" —
+	// same convention as train create/update (App.tsx handleUpdateTrain).
+	description: x.description ?? "",
 	drive_time_mm: x.driveTimeMm,
 	drive_time_ss: x.driveTimeSs,
 	is_operation_only_stop: x.isOperationOnlyStop,
@@ -330,7 +342,13 @@ export const toApiTimetableRow = (
 	arrive_str: x.arriveStr,
 	departure_str: x.departureStr,
 	marker_text: x.markerText,
-	work_type: x.workType,
+	// work_type is UNIMPLEMENTED (実装準備中): the backend column is a TINYINT
+	// enum whose only case is `none = 0`, so any free-text value (e.g. "荷役")
+	// is rejected with `Unknown WorkAtStationType`, which would brick the WHOLE
+	// row save and drop co-edited fields. Until the enum is implemented, omit it
+	// from the write path so the field degrades gracefully (silently discarded),
+	// exactly like the other model-only fields (showHH, arriveHidden). The input
+	// is still editable in the UI — see UNIMPLEMENTED.md §3-3.
 });
 
 // StationOnLine
@@ -347,7 +365,7 @@ export const fromApiStationOnLine = (api: ApiStationOnLine): StationOnLine => ({
 	locationM: api.location_m ?? 0,
 	longitude: api.location_lonlat?.longitude,
 	latitude: api.location_lonlat?.latitude,
-	trackHiddenByDefault: api.track_hidden_by_default,
+	trackHiddenByDefault: toBool(api.track_hidden_by_default),
 	createdAt:
 		api.created_at !== undefined ? new Date(api.created_at) : undefined,
 });
@@ -404,21 +422,21 @@ export const fromApiStopPatternRow = (
 	projectStationId: api.project_stations_id ?? "",
 	sortKey: api.sort_key,
 	trackName: api.track_name,
-	trackHidden: api.track_hidden,
-	isOperationOnlyStop: api.is_operation_only_stop,
-	isPass: api.is_pass,
+	trackHidden: toBool(api.track_hidden),
+	isOperationOnlyStop: toBool(api.is_operation_only_stop),
+	isPass: toBool(api.is_pass),
 	driveTimeMm: api.drive_time_mm,
 	driveTimeSs: api.drive_time_ss,
 	dwellTimeMm: api.dwell_time_mm,
 	dwellTimeSs: api.dwell_time_ss,
-	showArrive: api.show_arrive,
-	showDeparture: api.show_departure,
+	showArrive: toBool(api.show_arrive),
+	showDeparture: toBool(api.show_departure),
 	arriveStr: api.arrive_str,
 	departureStr: api.departure_str,
 	runInLimit: api.run_in_limit,
 	runOutLimit: api.run_out_limit,
 	remarks: api.remarks,
-	alwaysShowHh: api.always_show_hh,
+	alwaysShowHh: toBool(api.always_show_hh),
 	createdAt:
 		api.created_at !== undefined ? new Date(api.created_at) : undefined,
 });

--- a/frontend/src/api/hooks/useStationsOnLine.ts
+++ b/frontend/src/api/hooks/useStationsOnLine.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { fromApiStationOnLine, toApiStationOnLine } from "../adapters";
 import { client, fetchAllPages, unwrap, unwrapCreated } from "../client";
@@ -21,6 +21,30 @@ export const useStationsOnLine = (lineId: string) =>
 		},
 		enabled: lineId !== "",
 	});
+
+/** Fetch stationsOnLine for multiple lines in parallel and return the combined
+ *  flat array. Uses the same per-line queryKey as useStationsOnLine so results
+ *  are shared with the cache — no duplicate requests. Returns whatever is
+ *  already loaded; individual lines fill in as their queries complete. */
+export const useAllStationsOnLine = (lineIds: string[]): StationOnLine[] => {
+	const results = useQueries({
+		queries: lineIds.map((lineId) => ({
+			queryKey: queryKeys.stationsOnLine(lineId),
+			queryFn: async () => {
+				const data = await fetchAllPages((p, limit) =>
+					unwrap(
+						client.GET("/lines/{lineId}/stations_on_line", {
+							params: { path: { lineId }, query: { p, limit } },
+						})
+					)
+				);
+				return data.map(fromApiStationOnLine);
+			},
+			enabled: lineId !== "",
+		})),
+	});
+	return results.flatMap((r) => r.data ?? []);
+};
 
 export const useCreateStationOnLine = (lineId: string) => {
 	const queryClient = useQueryClient();

--- a/frontend/src/api/hooks/useTimetableRows.ts
+++ b/frontend/src/api/hooks/useTimetableRows.ts
@@ -17,7 +17,16 @@ const timetableRowsQueryOptions = (trainId: string) => ({
 				})
 			)
 		);
-		return data.map(fromApiTimetableRow);
+		// The API returns rows ordered by id DESC (reverse insertion). Rows must
+		// render in route/insertion order: first/last-row detection and the
+		// drive-time cascade (computeRowFormats) both depend on it. IDs are
+		// UUID v7 (lexicographically chronological), so sort by id ascending.
+		return data
+			.slice()
+			.sort((a, b) =>
+				(a.timetable_rows_id ?? "").localeCompare(b.timetable_rows_id ?? "")
+			)
+			.map(fromApiTimetableRow);
 	},
 });
 

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -309,6 +309,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/projects/{projectId}/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * エクスポートする
+         * @description Project の全グラフ (子エンティティを含む) を1つの ProjectGraph として取得する。
+         *
+         *     このProjectへのREAD権限が必要です。
+         */
+        get: operations["exportProject"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/import": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * インポートする
+         * @description ProjectGraph を読み込み、新しい Project として全グラフを複製する。すべての id はサーバ側で再採番される。
+         *
+         *     この操作にはサインインが必要です。
+         */
+        post: operations["importProject"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/projects/{projectId}/privileges": {
         parameters: {
             query?: never;
@@ -1125,6 +1169,21 @@ export interface components {
              * @enum {string}
              */
             readonly privilege_type?: "read" | "write" | "admin";
+        };
+        /** @description Project の全グラフ (エクスポート/インポート用バックアップ)。子エンティティは依存順の配列として平坦に保持され、インポート時に全 id はサーバ側で再採番される。 */
+        ProjectGraph: {
+            project: components["schemas"]["Project"];
+            colors?: components["schemas"]["Color"][];
+            stations?: components["schemas"]["Station"][];
+            station_tracks?: components["schemas"]["StationTrack"][];
+            lines?: components["schemas"]["Line"][];
+            stations_on_line?: components["schemas"]["StationOnLine"][];
+            stop_patterns?: components["schemas"]["StopPattern"][];
+            stop_pattern_rows?: components["schemas"]["StopPatternRow"][];
+            work_groups?: components["schemas"]["WorkGroup"][];
+            works?: components["schemas"]["Work"][];
+            trains?: components["schemas"]["Train"][];
+            timetable_rows?: components["schemas"]["TimetableRow"][];
         };
         ProjectsPrivilege: {
             /** @description UserID */
@@ -3303,6 +3362,99 @@ export interface operations {
             };
             /** @description コンテンツが存在しない */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorData"];
+                };
+            };
+        };
+    };
+    exportProject: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ProjectのID */
+                projectId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 取得成功 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectGraph"];
+                };
+            };
+            /** @description リクエストが不正 (Projectが大きすぎる等) */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorData"];
+                };
+            };
+            /** @description 認証トークンのエラー */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorData"];
+                };
+            };
+            /** @description コンテンツが存在しない */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorData"];
+                };
+            };
+        };
+    };
+    importProject: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description インポートする ProjectGraph */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProjectGraph"];
+            };
+        };
+        responses: {
+            /** @description 作成成功 (作成された Project を返す) */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Project"];
+                };
+            };
+            /** @description リクエストが不正 (payloadが大きすぎる等) */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorData"];
+                };
+            };
+            /** @description 認証トークンのエラー */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/api/transfer.ts
+++ b/frontend/src/api/transfer.ts
@@ -1,0 +1,93 @@
+// Project-graph transfer — thin wrappers over the dedicated backend endpoints.
+//
+// Export/import are now SERVER-side (GET /projects/{id}/export aggregates the
+// whole graph in one read transaction; POST /projects/import recreates it under
+// a brand-new Project in one write transaction, remapping every id server-side).
+// The client treats the graph envelope as an OPAQUE blob: it never walks the
+// tree, never remaps foreign keys, never parses entity fields. This sidesteps
+// the openapi-typescript readOnly-id stripping on the request type entirely
+// (the export output carries ids that the generated request type would drop) —
+// the blob is passed straight through as `unknown`.
+//
+// Replaces the previous client-side graph walk + fan-out create + old→new id
+// remap, all of which is the backend's job now.
+
+import { client, unwrap, unwrapCreated } from "./client";
+
+export const TRANSFER_KIND = "trvis-project-graph";
+export const BUNDLE_KIND = "trvis-project-graph-bundle";
+// v3: server-side opaque transfer (v2 was the client-side graph walk).
+export const TRANSFER_VERSION = 3;
+
+// On-disk single-project file: metadata envelope around the opaque backend
+// ProjectGraph. The "export all" path writes BUNDLE_KIND with a `graphs` array.
+export interface TransferFile {
+	version: number;
+	kind: string;
+	exportedAt: string;
+	graph: unknown;
+}
+
+/* ───────────────────────── Export ───────────────────────── */
+
+// Fetch the whole project graph from the backend. Opaque: callers only persist
+// the result; they never inspect it.
+export async function exportProjectGraph(projectId: string): Promise<unknown> {
+	return unwrap(
+		client.GET("/projects/{projectId}/export", {
+			params: { path: { projectId } },
+		})
+	);
+}
+
+/* ───────────────────────── Import ───────────────────────── */
+
+export interface ImportResult {
+	projectId: string;
+	name: string;
+}
+
+// POST an opaque graph envelope; the backend creates a fresh Project (201) and
+// returns it. `graph` is cast to `never` only to satisfy the generated request
+// type — the backend reads the raw body, including the readOnly ids the typed
+// request shape omits.
+export async function importProjectGraph(graph: unknown): Promise<ImportResult> {
+	const proj = await unwrapCreated(
+		client.POST("/projects/import", { body: graph as never })
+	);
+	const p = proj as { projects_id: string; name?: string };
+	return { projectId: p.projects_id, name: p.name ?? "" };
+}
+
+/* ───────────────────────── File parsing ───────────────────────── */
+
+// A bare backend envelope is recognisable by its `project` object.
+function isGraph(x: unknown): boolean {
+	return (
+		typeof x === "object" &&
+		x !== null &&
+		typeof (x as Record<string, unknown>)["project"] === "object" &&
+		(x as Record<string, unknown>)["project"] !== null
+	);
+}
+
+// Unwrap a single-file metadata envelope (`{ graph }`) to its backend graph;
+// a bare backend envelope passes through unchanged.
+function unwrapGraph(x: unknown): unknown {
+	if (typeof x === "object" && x !== null && "graph" in (x as object)) {
+		return (x as { graph: unknown }).graph;
+	}
+	return x;
+}
+
+// Extract every postable graph from an arbitrary loaded JSON file: a bundle
+// (`graphs` array), a single file envelope, or a bare backend envelope.
+export function extractGraphs(raw: unknown): unknown[] {
+	if (typeof raw !== "object" || raw === null) return [];
+	const o = raw as Record<string, unknown>;
+	if (o["kind"] === BUNDLE_KIND && Array.isArray(o["graphs"])) {
+		return (o["graphs"] as unknown[]).map(unwrapGraph).filter(isGraph);
+	}
+	const g = unwrapGraph(raw);
+	return isGraph(g) ? [g] : [];
+}

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -31,6 +31,7 @@ import {
 	useUpdateProjectStation,
 } from "../api/hooks/useProjectStations";
 import {
+	useAllStationsOnLine,
 	useCreateStationOnLine,
 	useDeleteStationOnLine,
 	useStationsOnLine,
@@ -584,6 +585,11 @@ export function App() {
 	const createStationOnLineMutation = useCreateStationOnLine(currentLine ?? "");
 	const updateStationOnLineMutation = useUpdateStationOnLine(currentLine ?? "");
 	const deleteStationOnLineMutation = useDeleteStationOnLine(currentLine ?? "");
+	// All lines' stationsOnLine combined — needed by ApplyPatternDialog and
+	// StopPatternWizard which may reference stop patterns on non-current lines.
+	const apiAllStationsOnLine = useAllStationsOnLine(
+		(apiLines ?? []).map((l) => l.id)
+	);
 
 	const [showStopPattern, setShowStopPattern] = useState(false);
 	const [editingPattern, setEditingPattern] = useState<StopPattern | null>(
@@ -667,6 +673,9 @@ export function App() {
 
 	const modelLines = (apiLines ?? []).map(entityLineToModel);
 	const modelStationsOnLine = (apiStationsOnLine ?? []).map(
+		entityStationOnLineToModel
+	);
+	const modelAllStationsOnLine = apiAllStationsOnLine.map(
 		entityStationOnLineToModel
 	);
 	const modelStopPatterns = (apiStopPatterns ?? []).map((sp) =>
@@ -1474,13 +1483,10 @@ export function App() {
 						stopPatterns={modelStopPatterns}
 						stations={modelProjectStations}
 						colors={apiColors ?? []}
-						// Use the API-backed lines/stations-on-line, not the
-						// in-memory sample `data` (which made the apply-pattern
-						// dialog's line dropdown show fictional sample lines).
-						// NOTE: modelStationsOnLine is scoped to the currently
-						// selected line (useStationsOnLine(currentLine)); full
-						// cross-line provisioning is a follow-up (see UNIMPLEMENTED.md §2-4).
-						stationsOnLine={modelStationsOnLine}
+						// All lines' stationsOnLine so ApplyPatternDialog can
+						// resolve stop patterns that reference any line in the project,
+						// not just the currently selected one.
+						stationsOnLine={modelAllStationsOnLine}
 						lines={modelLines}
 						onCreateRow={handleCreateRow}
 						onUpdateRow={handleUpdateRow}
@@ -1562,7 +1568,7 @@ export function App() {
 						key={editingPattern?.id ?? "new"}
 						lines={modelLines}
 						stations={modelProjectStations}
-						stationsOnLine={modelStationsOnLine}
+						stationsOnLine={modelAllStationsOnLine}
 						t={t}
 						editPattern={liveEditingPattern}
 						onSave={(sp) => {

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -74,6 +74,14 @@ import {
 	useWorks,
 } from "../api/hooks/useWorks";
 import { queryKeys } from "../api/queryKeys";
+import {
+	exportProjectGraph,
+	importProjectGraph,
+	extractGraphs,
+	TRANSFER_KIND,
+	BUNDLE_KIND,
+	TRANSFER_VERSION,
+} from "../api/transfer";
 import { AppShell } from "../components/AppShell";
 import AuthControls from "../components/auth/AuthControls";
 import {
@@ -88,7 +96,6 @@ import { LineManager } from "../components/LineManager";
 import { ProjectListScreen } from "../components/ProjectList";
 import { StopPatternWizard } from "../components/StopPatternWizard";
 import { WorkBrowser } from "../components/WorkBrowser";
-import { createInitialData } from "../data/sampleData";
 
 import { useSettings } from "./SettingsContext";
 
@@ -107,7 +114,6 @@ import type {
 	Work as EntityWork,
 } from "../types/entities";
 import type {
-	AppData,
 	Line,
 	Project,
 	Station,
@@ -316,14 +322,6 @@ function modelStopRowToEntityDraft(
 	};
 }
 
-function uid(prefix: string): string {
-	return (
-		prefix +
-		Date.now().toString(36) +
-		Math.random().toString(36).slice(2, 6)
-	);
-}
-
 function downloadJson(filename: string, obj: unknown) {
 	const blob = new Blob([JSON.stringify(obj, null, 2)], {
 		type: "application/json",
@@ -526,16 +524,6 @@ function SidebarTree({
 	);
 }
 
-interface ImportedJson {
-	kind?: string;
-	projects?: Project[];
-	lines?: Line[];
-	stations?: AppData["stations"];
-	stationsOnLine?: StationOnLine[];
-	stopPatterns?: StopPattern[];
-	project?: Project;
-}
-
 export function App() {
 	const { theme, toggleTheme, lang, toggleLang, density, t } =
 		useSettings();
@@ -550,7 +538,6 @@ export function App() {
 	const updateProjectMutation = useUpdateProject();
 	const deleteProjectMutation = useDeleteProject();
 
-	const [data, setData] = useState<AppData>(() => createInitialData());
 	const [projectId, setProjectId] = useState<string | null>(null);
 
 	const { data: apiWorkGroups } = useWorkGroups(projectId ?? "");
@@ -691,24 +678,30 @@ export function App() {
 		)
 	);
 
+	// Auto-select a WG (then its first work) when on the work screen. The work
+	// list (apiWorks) only loads for the *current* WG, so a WG must be selected
+	// before any works appear. WGs and works load asynchronously, so this must
+	// re-run as that data arrives — keying only on [screen, projectId] fires
+	// before apiWorkGroups is ready (e.g. a cold reload), leaves currentWG null,
+	// and the sidebar then shows every WG with 0 works. Drive it off scalar
+	// validity/first-id signals instead so each stage settles once its data is in.
+	const firstWGId = apiWorkGroups?.[0]?.id;
+	const currentWGValid =
+		currentWG != null && !!apiWorkGroups?.some((g) => g.id === currentWG);
+	const firstWorkId = wg?.works[0]?.id;
+	const currentWorkValid =
+		currentWork != null && !!wg?.works.some((w) => w.id === currentWork);
 	useEffect(() => {
-		if (
-			screen === "work" &&
-			project &&
-			(!currentWork || !wg?.works.find((w) => w.id === currentWork))
-		) {
-			const firstWG = project.workGroups[0];
-			const firstWork = firstWG?.works[0];
-			if (firstWG && firstWork) {
-				setCurrentWG(firstWG.id);
-				setCurrentWork(firstWork.id);
-			} else if (firstWG) {
-				setCurrentWG(firstWG.id);
-				setCurrentWork(null);
-			}
+		if (screen !== "work" || !project) return;
+		if (!currentWGValid && firstWGId) {
+			// No (valid) WG selected yet — pick the first once WGs have loaded.
+			setCurrentWG(firstWGId);
+		} else if (currentWGValid && !currentWorkValid && firstWorkId) {
+			// WG selected and its works have loaded — pick the first work.
+			setCurrentWork(firstWorkId);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [screen, projectId]);
+	}, [screen, projectId, currentWGValid, firstWGId, currentWorkValid, firstWorkId]);
 
 	// Auto-select first line when navigating to the lines screen with no line selected.
 	useEffect(() => {
@@ -1238,90 +1231,84 @@ export function App() {
 		}
 	};
 
-	/* ─── JSON Import / Export ─── */
-	const exportProject = (pid: string) => {
-		const p = data.projects.find((x) => x.id === pid);
-		if (!p) return;
-		const safeName = (p.name || "project").replace(/[^\w.-]+/g, "_");
-		downloadJson(`${safeName}.json`, {
-			version: 1,
-			kind: "trvis-project",
-			exportedAt: new Date().toISOString(),
-			project: p,
-			lines: data.lines,
-			stations: data.stations,
-			stationsOnLine: data.stationsOnLine,
-			stopPatterns: data.stopPatterns,
-		});
-	};
-	const exportAll = () => {
-		downloadJson("trvis-all.json", {
-			version: 1,
-			kind: "trvis-all",
-			exportedAt: new Date().toISOString(),
-			...data,
-		});
-	};
-	const mergeById = <T extends { id: string }>(
-		existing: T[],
-		incoming: T[]
-	): T[] => {
-		const map = new Map(existing.map((x) => [x.id, x]));
-		incoming.forEach((x) => map.set(x.id, x));
-		return [...map.values()];
-	};
-	const importJson = (raw: unknown) => {
+	/* ─── JSON Import / Export (dedicated backend API) ─── */
+	// The graph is fetched/sent opaquely; the client only wraps it in a small
+	// metadata envelope for the file (and a BUNDLE_KIND array for "export all").
+
+	const exportProject = async (pid: string) => {
+		const p = apiProjects?.find((x) => x.id === pid);
+		if (p === undefined) {
+			alert("プロジェクトが見つかりません。");
+			return;
+		}
 		try {
-			if (typeof raw !== "object" || raw === null) {
-				alert("未対応のJSON形式です。");
+			const graph = await exportProjectGraph(pid);
+			const safeName = (p.name || "project").replace(/[^\w.-]+/g, "_");
+			downloadJson(`${safeName}.json`, {
+				version: TRANSFER_VERSION,
+				kind: TRANSFER_KIND,
+				exportedAt: new Date().toISOString(),
+				graph,
+			});
+		} catch (e) {
+			alert(
+				"エクスポートに失敗しました: " +
+					(e instanceof Error ? e.message : String(e))
+			);
+		}
+	};
+	const exportAll = async () => {
+		const projects = apiProjects ?? [];
+		if (projects.length === 0) {
+			alert("エクスポートできるプロジェクトがありません。");
+			return;
+		}
+		try {
+			// Export sequentially rather than Promise.all(...) — a fan-out of one
+			// full-graph export per project (potentially hundreds) overwhelms the
+			// backend and stalls the download. A simple awaiting loop bounds
+			// concurrency to one; output is identical.
+			const graphs: unknown[] = [];
+			for (const p of projects) {
+				graphs.push(await exportProjectGraph(p.id));
+			}
+			downloadJson("trvis-all.json", {
+				version: TRANSFER_VERSION,
+				kind: BUNDLE_KIND,
+				exportedAt: new Date().toISOString(),
+				graphs,
+			});
+		} catch (e) {
+			alert(
+				"エクスポートに失敗しました: " +
+					(e instanceof Error ? e.message : String(e))
+			);
+		}
+	};
+	const importJson = async (raw: unknown) => {
+		try {
+			const graphs = extractGraphs(raw);
+			if (graphs.length === 0) {
+				alert(
+					"未対応のJSON形式です（旧サンプル形式は廃止。trvis-project-graph 形式のみ取込可）。"
+				);
 				return;
 			}
-			const json = raw as ImportedJson;
-			if (json.kind === "trvis-all" && Array.isArray(json.projects)) {
-				if (
-					!confirm(
-						`全データ (${json.projects.length} プロジェクト) を読み込みます。現在のデータは置き換えられます。よろしいですか？`
-					)
+			if (
+				!confirm(
+					`${graphs.length} プロジェクトを新規取込します（既存データは変更されません）。よろしいですか？`
 				)
-					return;
-				setData({
-					projects: json.projects,
-					lines: json.lines || [],
-					stations: json.stations || [],
-					stationsOnLine: json.stationsOnLine || [],
-					stopPatterns: json.stopPatterns || [],
-				});
-			} else if (json.kind === "trvis-project" && json.project) {
-				setData((d) => {
-					const incoming = json.project as Project;
-					const exists = d.projects.some(
-						(p) => p.id === incoming.id
-					);
-					const newProj: Project = exists
-						? {
-								...incoming,
-								id: uid("p"),
-								name: incoming.name + " (取込)",
-							}
-						: incoming;
-					return {
-						...d,
-						projects: [...d.projects, newProj],
-						lines: mergeById(d.lines, json.lines || []),
-						stations: mergeById(d.stations, json.stations || []),
-						stationsOnLine: mergeById(
-							d.stationsOnLine,
-							json.stationsOnLine || []
-						),
-						stopPatterns: mergeById(
-							d.stopPatterns,
-							json.stopPatterns || []
-						),
-					};
-				});
-			} else {
-				alert("未対応のJSON形式です。");
+			) {
+				return;
 			}
+			const results = [];
+			for (const g of graphs) {
+				results.push(await importProjectGraph(g));
+			}
+			await queryClient.invalidateQueries({
+				queryKey: queryKeys.projects(),
+			});
+			alert(`取込完了: ${results.length} プロジェクトを作成しました。`);
 		} catch (e) {
 			alert(
 				"インポートに失敗しました: " +
@@ -1487,8 +1474,14 @@ export function App() {
 						stopPatterns={modelStopPatterns}
 						stations={modelProjectStations}
 						colors={apiColors ?? []}
-						stationsOnLine={data.stationsOnLine}
-						lines={data.lines}
+						// Use the API-backed lines/stations-on-line, not the
+						// in-memory sample `data` (which made the apply-pattern
+						// dialog's line dropdown show fictional sample lines).
+						// NOTE: modelStationsOnLine is scoped to the currently
+						// selected line (useStationsOnLine(currentLine)); full
+						// cross-line provisioning is a follow-up (see UNIMPLEMENTED.md §2-4).
+						stationsOnLine={modelStationsOnLine}
+						lines={modelLines}
 						onCreateRow={handleCreateRow}
 						onUpdateRow={handleUpdateRow}
 						onDeleteRow={handleDeleteRow}

--- a/frontend/src/components/EntityDialogs.tsx
+++ b/frontend/src/components/EntityDialogs.tsx
@@ -369,11 +369,20 @@ interface ContextMenuProps {
 
 export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
 	useEffect(() => {
+		// Attach the dismiss listeners on the NEXT tick. The right-click that
+		// opened this menu is a discrete event; React 18 flushes its state update
+		// (and this mount + effect) synchronously, while the same contextmenu
+		// event is still propagating to window — so attaching synchronously made
+		// the opening event immediately dismiss the menu. Deferring one tick lets
+		// that event finish first; subsequent clicks/right-clicks/keys still close.
 		const close = () => onClose();
-		window.addEventListener("click", close);
-		window.addEventListener("contextmenu", close);
-		window.addEventListener("keydown", close);
+		const id = setTimeout(() => {
+			window.addEventListener("click", close);
+			window.addEventListener("contextmenu", close);
+			window.addEventListener("keydown", close);
+		}, 0);
 		return () => {
+			clearTimeout(id);
 			window.removeEventListener("click", close);
 			window.removeEventListener("contextmenu", close);
 			window.removeEventListener("keydown", close);

--- a/frontend/src/components/TimetableGrid.tsx
+++ b/frontend/src/components/TimetableGrid.tsx
@@ -140,20 +140,30 @@ function TimeCell({
 	const commit = () => {
 		setEditing(false);
 		const trimmed = draft.trim();
+		// Emit exactly ONE change per commit. Previously the valid-time branch
+		// called onChange(value) AND onChangeText("") — two separate updateRow()
+		// calls that each spread the SAME stale rows[idx], so the second
+		// (text="") clobbered the first's value back to empty and fired a racing
+		// null PUT (which aborted). Each consumer handler now sets BOTH the time
+		// and its display-text in a single update, so one call suffices here.
 		if (trimmed === "") {
 			onChange("");
-			onChangeText && onChangeText("");
 			return;
 		}
 		const normalized = TRViSTime.normalize(trimmed);
 		const isTime = /^\d{1,3}:\d{2}:\d{2}$/.test(normalized);
 		if (isTime) {
 			onChange(normalized);
-			onChangeText && onChangeText("");
+		} else if (onChangeText) {
+			onChangeText(trimmed);
 		} else {
 			onChange("");
-			onChangeText && onChangeText(trimmed);
 		}
+	};
+
+	const startEditing = (initialDraft: string) => {
+		setDraft(initialDraft);
+		setEditing(true);
 	};
 
 	useEffect(() => {
@@ -198,10 +208,7 @@ function TimeCell({
 		return (
 			<span
 				className="time-display"
-				onClick={() => {
-					setDraft(displayText);
-					setEditing(true);
-				}}
+				onClick={() => startEditing(displayText)}
 				title={`表示文字列: ${displayText} — クリックして編集`}
 				style={{ textAlign: "center", justifyContent: "center" }}>
 				<span
@@ -222,10 +229,7 @@ function TimeCell({
 	return (
 		<span
 			className="time-display"
-			onClick={() => {
-				setDraft(editDraft);
-				setEditing(true);
-			}}
+			onClick={() => startEditing(editDraft)}
 			title={value ? `${value} — クリックして編集` : "クリックして編集"}
 			style={{ textAlign: "center", justifyContent: "center" }}>
 			{hasFormatted ? (
@@ -989,12 +993,13 @@ interface StationRowProps {
 	fmt: Partial<RowFormat>;
 	colors: EntityColor[];
 	onUpdateRow: <K extends keyof TimetableRow>(idx: number, key: K, val: TimetableRow[K]) => void;
+	onUpdateRowFields: (idx: number, partial: Partial<TimetableRow>) => void;
 	onDeleteRow: (idx: number) => void;
 	onOpenDetail: () => void;
 	t: Strings;
 }
 
-function StationRow({ row, idx, isLast, fmt, colors, onUpdateRow, onDeleteRow, onOpenDetail, t }: StationRowProps) {
+function StationRow({ row, idx, isLast, fmt, colors, onUpdateRow, onUpdateRowFields, onDeleteRow, onOpenDetail, t }: StationRowProps) {
 	const [remarksDraft, setRemarksDraft] = useState(row.remarks);
 
 	// Reseed when the row data changes (e.g. after a mutation refetch).
@@ -1053,8 +1058,8 @@ function StationRow({ row, idx, isLast, fmt, colors, onUpdateRow, onDeleteRow, o
 					value={row.arrive}
 					displayText={row.arriveDisplayText || undefined}
 					formattedValue={row.arriveDisplayText ? undefined : fmt.arriveFormatted}
-					onChange={(v) => onUpdateRow(idx, "arrive", v)}
-					onChangeText={(v) => onUpdateRow(idx, "arriveDisplayText", v)}
+					onChange={(v) => onUpdateRowFields(idx, { arrive: v, arriveDisplayText: "" })}
+					onChangeText={(v) => onUpdateRowFields(idx, { arrive: "", arriveDisplayText: v })}
 					muted={!!row.arriveHidden}
 				/>
 			</td>
@@ -1077,8 +1082,8 @@ function StationRow({ row, idx, isLast, fmt, colors, onUpdateRow, onDeleteRow, o
 						value={row.departure}
 						displayText={row.departureDisplayText || undefined}
 						formattedValue={row.departureDisplayText ? undefined : fmt.departureFormatted}
-						onChange={(v) => onUpdateRow(idx, "departure", v)}
-						onChangeText={(v) => onUpdateRow(idx, "departureDisplayText", v)}
+						onChange={(v) => onUpdateRowFields(idx, { departure: v, departureDisplayText: "" })}
+						onChangeText={(v) => onUpdateRowFields(idx, { departure: "", departureDisplayText: v })}
 						muted={!!row.departureHidden}
 					/>
 				)}
@@ -1278,6 +1283,20 @@ export function TimetableGrid({ train, stations, colors, onCreateRow, onUpdateRo
 		[rows, onUpdateRow]
 	);
 
+	// Apply several fields in ONE update (one spread, one PUT). Needed where two
+	// related fields change together (time vs its display-text): two single-key
+	// updateRow calls would each read the same stale rows[idx] and the second
+	// would clobber the first.
+	const updateRowFields = useCallback(
+		(idx: number, partial: Partial<TimetableRow>) => {
+			const row = rows[idx];
+			if (!row) return;
+			onUpdateRow(row.id, { ...row, ...partial });
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[rows, onUpdateRow]
+	);
+
 	const deleteRow = (idx: number) => {
 		const row = rows[idx];
 		if (!row) return;
@@ -1383,6 +1402,7 @@ export function TimetableGrid({ train, stations, colors, onCreateRow, onUpdateRo
 									fmt={fmt}
 									colors={colors}
 									onUpdateRow={updateRow}
+									onUpdateRowFields={updateRowFields}
 									onDeleteRow={deleteRow}
 									onOpenDetail={() => setDetailRow(row)}
 									t={t}

--- a/frontend/src/components/WorkBrowser.tsx
+++ b/frontend/src/components/WorkBrowser.tsx
@@ -1,6 +1,6 @@
 // WorkBrowser — train master/detail layout: train list + timetable grid.
 // Ported from WorkBrowser.jsx.
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { ApplyPatternDialog } from "./ApplyPatternDialog";
 import { BBCodeField } from "./BBCodeEditor";
@@ -662,6 +662,25 @@ export function WorkBrowser({
 		setSelectedTrainId(id);
 		onSelectTrain(id);
 	};
+
+	// Auto-select the first train so the timetable grid mounts. The useState
+	// initializer above only runs once at mount, when work.trains is usually
+	// still empty (trains load async via useTrains, and a freshly created train
+	// arrives after mount). Re-select whenever the current selection is missing
+	// (null, or no longer in the list) and trains are available. Mirrors the
+	// WG/work auto-select effect in App.tsx. Must call selectTrain (not just
+	// setSelectedTrainId) so App.tsx's currentTrain is set too, otherwise
+	// useTimetableRows(currentTrain) stays empty and rows never load.
+	const firstTrainId = work.trains[0]?.id ?? null;
+	const selectionValid =
+		selectedTrainId != null &&
+		work.trains.some((tr) => tr.id === selectedTrainId);
+	useEffect(() => {
+		if (!selectionValid && firstTrainId) {
+			selectTrain(firstTrainId);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [selectionValid, firstTrainId]);
 
 	const updateTrain = (updated: Train) => {
 		onUpdateTrain({ id: updated.id, ...modelTrainToEntityDraft(updated) });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,4 +8,15 @@ export default defineConfig({
 	esbuild: {
 		drop: ["console", "debugger"],
 	},
+	// Dev-only: proxy API calls to the dockerized backend (php at :8080) so
+	// `yarn dev` on localhost:5173 talks to the same /api/v1 surface as the
+	// nginx-proxied production stack. Has no effect on `vite build`/`preview`.
+	server: {
+		proxy: {
+			"/api": {
+				target: "http://localhost:8080",
+				changeOrigin: true,
+			},
+		},
+	},
 });

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1735,6 +1735,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
+  dependencies:
+    playwright: "npm:1.60.0"
+  bin:
+    playwright: cli.js
+  checksum: 10c0/86b06e6437933e741c7cd43f362024e857e7bc28a55fcbb0553ef55e01a2a403c64f4786868de8af86a6e303fe99e98a18a42ba19489f43ae122e457f9e2d189
+  languageName: node
+  linkType: hard
+
 "@popperjs/core@npm:^2.11.8":
   version: 2.11.8
   resolution: "@popperjs/core@npm:2.11.8"
@@ -4253,12 +4264,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -5755,6 +5785,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/99ccd43923b6e9355e0723b7fe221e6326efd4687f8dafff951313662aea11db51f542a9c2122c704c445fb9baae1c9ec9fa6f895126bbddd9fe92313f6942c9
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.60.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/714ad76d85b4865d7e43c0012f9039800c1485373388973ed39d79339cee5ad467052d1e2f1eaeca107a1cb6e65342186a8578a4c3504853d84c3a691250d5db
+  languageName: node
+  linkType: hard
+
 "pluralize@npm:8.0.0":
   version: 8.0.0
   resolution: "pluralize@npm:8.0.0"
@@ -7186,6 +7240,7 @@ __metadata:
     "@mui/material": "npm:^5.15.4"
     "@mui/x-data-grid": "npm:^6.18.7"
     "@mui/x-date-pickers": "npm:^6.19.3"
+    "@playwright/test": "npm:^1.60.0"
     "@reduxjs/toolkit": "npm:^2.0.1"
     "@tanstack/react-query": "npm:^5.100.10"
     "@tsconfig/strictest": "npm:^2.0.2"


### PR DESCRIPTION
## Summary

- **Backend**: Add `GET /projects/{id}/export` and `POST /projects/import` endpoints backed by `ProjectTransferService` — aggregates the full project graph in a single transaction and remaps all IDs on import. Includes supporting type-coercion fixes (string UUID / date strings → typed objects in service layer) that were causing hard 500s on normal create operations.
- **Frontend**: Rewire export/import to call the real backend API (`transfer.ts`); fix `tinyint(1)` fields (0/1 over wire, not JSON `true`/`false`) with `toBool()` coercion; omit `work_type` from write path (実装準備中 — any non-empty value would brick the whole row save); fix `description` default for new timetable rows; supply all-lines `stationsOnLine` to `ApplyPatternDialog` + `StopPatternWizard` via new `useAllStationsOnLine` hook.
- **E2E**: Add full Playwright suite (71 tests) covering all major UI flows. Includes `globalTeardown` that deletes E2E users' projects after each run, preventing accumulated test artifacts from flaking the `createProject` setup helper (root cause: 639 stale projects → `fetchAllPages` × 7 pages + un-virtualized render raced the 10s card-visible wait).

## Commits

- `dc3fed0` feat(backend): project export/import transfer API + type-coercion fixes for direct-service callers
- `b751e57` feat(frontend): rewire export/import to backend API; fix tinyint→bool coercion + work_type write path
- `e025cd6` test(e2e): full E2E suite (71 tests) with global teardown
- `41b4cd4` feat(frontend): supply all-lines stationsOnLine to ApplyPatternDialog + StopPatternWizard

## Test plan

- [ ] E2E suite: `cd frontend && yarn playwright test --project=chromium` → 71/71 passed (~2m)
- [ ] CI gate: `yarn tsc --noEmit && yarn vite build` — passes
- [ ] Backend: `docker compose run --rm php vendor/bin/phpunit` — existing integration tests pass
- [ ] Manual: create project → add line + stations + stop pattern → apply pattern in WorkBrowser → verify stations from correct line appear in dialog
- [ ] Manual: export project via card menu → import via file input → verify new card appears with same name

🤖 Generated with [Claude Code](https://claude.com/claude-code)