### PR TITLE
fix(frontend): guard Enter handlers against IME composition (#28)

### DIFF
--- a/frontend/src/components/LineManager.tsx
+++ b/frontend/src/components/LineManager.tsx
@@ -418,29 +418,33 @@ const StationsTab = ({
 									{isEditing ? (
 										<>
 											<td style={{ padding: "4px 4px" }}>
-												<ICell
-													inputRef={firstInputRef}
-													value={draft.stationName}
-													onChange={(v) => {
-														set("stationName", v as string);
-													}}
-													onKeyDown={(e) => {
-														handleKeyDown(e, false);
-													}}
-													placeholder="横浜"
-												/>
+												<form onSubmit={(e) => { e.preventDefault(); commit(); }} style={{ margin: 0 }}>
+													<ICell
+														inputRef={firstInputRef}
+														value={draft.stationName}
+														onChange={(v) => {
+															set("stationName", v as string);
+														}}
+														onKeyDown={(e) => {
+															if (e.key === "Escape") { e.preventDefault(); cancelEdit(); }
+														}}
+														placeholder="横浜"
+													/>
+												</form>
 											</td>
 											<td style={{ padding: "4px 4px" }}>
-												<ICell
-													value={draft.fullName}
-													onChange={(v) => {
-														set("fullName", v as string);
-													}}
-													onKeyDown={(e) => {
-														handleKeyDown(e, false);
-													}}
-													placeholder="横浜駅"
-												/>
+												<form onSubmit={(e) => { e.preventDefault(); commit(); }} style={{ margin: 0 }}>
+													<ICell
+														value={draft.fullName}
+														onChange={(v) => {
+															set("fullName", v as string);
+														}}
+														onKeyDown={(e) => {
+															if (e.key === "Escape") { e.preventDefault(); cancelEdit(); }
+														}}
+														placeholder="横浜駅"
+													/>
+												</form>
 											</td>
 											<td style={{ padding: "4px 4px" }}>
 												<ICell
@@ -712,29 +716,33 @@ const StationsTab = ({
 									新
 								</td>
 								<td style={{ padding: "4px 4px" }}>
-									<ICell
-										inputRef={firstInputRef}
-										value={draft.stationName}
-										onChange={(v) => {
-											set("stationName", v as string);
-										}}
-										onKeyDown={(e) => {
-											handleKeyDown(e, false);
-										}}
-										placeholder="駅名（短）"
-									/>
+									<form onSubmit={(e) => { e.preventDefault(); commit(); }} style={{ margin: 0 }}>
+										<ICell
+											inputRef={firstInputRef}
+											value={draft.stationName}
+											onChange={(v) => {
+												set("stationName", v as string);
+											}}
+											onKeyDown={(e) => {
+												if (e.key === "Escape") { e.preventDefault(); cancelEdit(); }
+											}}
+											placeholder="駅名（短）"
+										/>
+									</form>
 								</td>
 								<td style={{ padding: "4px 4px" }}>
-									<ICell
-										value={draft.fullName}
-										onChange={(v) => {
-											set("fullName", v as string);
-										}}
-										onKeyDown={(e) => {
-											handleKeyDown(e, false);
-										}}
-										placeholder="フルネーム"
-									/>
+									<form onSubmit={(e) => { e.preventDefault(); commit(); }} style={{ margin: 0 }}>
+										<ICell
+											value={draft.fullName}
+											onChange={(v) => {
+												set("fullName", v as string);
+											}}
+											onKeyDown={(e) => {
+												if (e.key === "Escape") { e.preventDefault(); cancelEdit(); }
+											}}
+											placeholder="フルネーム"
+										/>
+									</form>
 								</td>
 								<td style={{ padding: "4px 4px" }}>
 									<ICell
@@ -915,39 +923,46 @@ const QuickAddBar = ({ stations, onAdd }: QuickAddBarProps) => {
 				flex: 1,
 				alignItems: "center",
 			}}>
-			<input
-				ref={ref}
-				value={name}
-				onChange={(e) => {
-					setName(e.target.value);
+			<form
+				onSubmit={(e) => {
+					e.preventDefault();
+					submit();
 				}}
-				onKeyDown={(e) => {
-					if (e.key === "Enter" && !e.nativeEvent.isComposing) {
-						e.preventDefault();
-						submit();
-					}
-				}}
-				placeholder="駅名を入力してEnter — 複数連続で追加できます"
 				style={{
+					display: "flex",
+					gap: 6,
 					flex: 1,
-					padding: "5px 10px",
-					border: "1px solid var(--color-border)",
-					borderRadius: "var(--radius)",
-					fontSize: 13,
-					background: "var(--color-content)",
-					color: "var(--color-text)",
-					outline: "none",
-					fontFamily: "var(--font-main)",
-				}}
-				onFocus={(e) => (e.target.style.borderColor = "var(--color-accent)")}
-				onBlur={(e) => (e.target.style.borderColor = "var(--color-border)")}
-			/>
-			<button
-				className="btn btn-primary btn-sm"
-				onClick={submit}
-				disabled={!name.trim()}>
-				追加
-			</button>
+					alignItems: "center",
+					margin: 0,
+				}}>
+				<input
+					ref={ref}
+					value={name}
+					onChange={(e) => {
+						setName(e.target.value);
+					}}
+					placeholder="駅名を入力してEnter — 複数連続で追加できます"
+					style={{
+						flex: 1,
+						padding: "5px 10px",
+						border: "1px solid var(--color-border)",
+						borderRadius: "var(--radius)",
+						fontSize: 13,
+						background: "var(--color-content)",
+						color: "var(--color-text)",
+						outline: "none",
+						fontFamily: "var(--font-main)",
+					}}
+					onFocus={(e) => (e.target.style.borderColor = "var(--color-accent)")}
+					onBlur={(e) => (e.target.style.borderColor = "var(--color-border)")}
+				/>
+				<button
+					type="submit"
+					className="btn btn-primary btn-sm"
+					disabled={!name.trim()}>
+					追加
+				</button>
+			</form>
 			<span
 				style={{
 					fontSize: 11,

--- a/frontend/src/components/LineManager.tsx
+++ b/frontend/src/components/LineManager.tsx
@@ -267,7 +267,7 @@ const StationsTab = ({
 		e: KeyboardEvent<HTMLInputElement>,
 		isLast: boolean
 	) => {
-		if (e.key === "Enter") {
+		if (e.key === "Enter" && !e.nativeEvent.isComposing) {
 			e.preventDefault();
 			commit();
 		}
@@ -922,7 +922,7 @@ const QuickAddBar = ({ stations, onAdd }: QuickAddBarProps) => {
 					setName(e.target.value);
 				}}
 				onKeyDown={(e) => {
-					if (e.key === "Enter") {
+					if (e.key === "Enter" && !e.nativeEvent.isComposing) {
 						e.preventDefault();
 						submit();
 					}
@@ -1088,7 +1088,7 @@ const LineStationsTab = ({
 	const handleKeyDown = (
 		e: KeyboardEvent<HTMLInputElement | HTMLSelectElement>
 	) => {
-		if (e.key === "Enter") {
+		if (e.key === "Enter" && !e.nativeEvent.isComposing) {
 			e.preventDefault();
 			commitSol();
 		}

--- a/frontend/src/components/TimetableGrid.tsx
+++ b/frontend/src/components/TimetableGrid.tsx
@@ -179,7 +179,7 @@ const TimeCell = ({
 				}}
 				onBlur={commit}
 				onKeyDown={(e) => {
-					if (e.key === "Enter" || e.key === "Tab") {
+					if ((e.key === "Enter" && !e.nativeEvent.isComposing) || e.key === "Tab") {
 						e.preventDefault();
 						commit();
 						onKeyDown?.(e);


### PR DESCRIPTION
## Summary

- Fixes Enter key firing prematurely during Japanese IME composition in station name / quick-add inputs
- Initial fix used `!e.nativeEvent.isComposing`; follow-up commit switches Japanese text inputs to `<form onSubmit>` to cover Safari

## Root cause

**Chrome / Firefox:** `keydown` fires while `isComposing` is still `true` → `!e.nativeEvent.isComposing` correctly blocks the action.

**Safari:** `compositionend` fires *before* `keydown`, so `isComposing` is already `false` when the handler runs → the initial guard silently broke on Safari.

The browser-native form `submit` event is IME-aware and never fires for composition-confirming Enter across all browsers, making it the correct primitive for text inputs.

## Changes

**Commit 1** — `isComposing` guard on all four Enter handlers (Chrome/Firefox fix):

| File | Handler | Action |
|---|---|---|
| `LineManager.tsx` | `StationsTab.handleKeyDown` | station row commit |
| `LineManager.tsx` | `QuickAddBar` inline handler | quick-add station submit |
| `LineManager.tsx` | `LineStationsTab.handleKeyDown` | station-on-line row commit |
| `TimetableGrid.tsx` | `TimeCell` inline handler | time cell commit |

**Commit 2** — `<form onSubmit>` for Japanese text inputs (Safari fix):

| Location | Approach |
|---|---|
| `QuickAddBar` input+button | Wrapped in `<form onSubmit={submit}>`, removed manual `onKeyDown` Enter guard |
| `StationsTab` stationName / fullName (existing + new rows) | Each `ICell` wrapped in `<form onSubmit={commit}>`; `onKeyDown` retains Escape only |

Number inputs, `<select>`, and `TimeCell` are unchanged — they don't use IME so the `isComposing` guard is sufficient.

## Test plan

- [ ] Type a Japanese station name using IME; confirm conversion with Enter — should **not** save
- [ ] Press Enter after finishing composition — **should** save
- [ ] **Safari + Japanese IME**: same two checks above (was broken before commit 2)
- [ ] Quick-add bar: same IME behavior
- [ ] Tab still commits (number / last-field inputs)
- [ ] Escape still cancels

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)