### PR TITLE
feat(frontend): add loading spinners throughout app (fixes #26)

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -354,6 +354,7 @@ type ConfirmState = {
 
 type SidebarTreeProps = {
 	readonly project?: Project;
+	readonly isLoadingWorkGroups: boolean;
 	readonly currentScreen: Screen;
 	readonly currentWG: string | null;
 	readonly currentWork: string | null;
@@ -375,6 +376,7 @@ type SidebarTreeProps = {
 
 const SidebarTree = ({
 	project,
+	isLoadingWorkGroups,
 	currentScreen,
 	currentWG,
 	currentWork,
@@ -409,6 +411,17 @@ const SidebarTree = ({
 					style={{ paddingBottom: 6 }}>
 					{project.name}
 				</div>
+				{isLoadingWorkGroups && project.workGroups.length === 0 ? (
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							padding: "16px 0",
+						}}>
+						<span className="spinner" />
+					</div>
+				) : null}
 				{project.workGroups.map((wg) => (
 					<div key={wg.id}>
 						<div style={{ display: "flex", alignItems: "center" }}>
@@ -542,7 +555,7 @@ export const App = () => {
 
 	const [projectId, setProjectId] = useState<string | null>(null);
 
-	const { data: apiWorkGroups } = useWorkGroups(projectId ?? "");
+	const { data: apiWorkGroups, isLoading: workGroupsLoading } = useWorkGroups(projectId ?? "");
 	const createWGMutation = useCreateWorkGroup(projectId ?? "");
 	const updateWGMutation = useUpdateWorkGroup(projectId ?? "");
 	const deleteWGMutation = useDeleteWorkGroup(projectId ?? "");
@@ -556,7 +569,7 @@ export const App = () => {
 	const updateWorkMutation = useUpdateWork(currentWG ?? "");
 	const deleteWorkMutation = useDeleteWork(currentWG ?? "");
 
-	const { data: apiTrains } = useTrains(currentWork ?? "");
+	const { data: apiTrains, isLoading: trainsLoading } = useTrains(currentWork ?? "");
 	const createTrainMutation = useCreateTrain(currentWork ?? "");
 	const updateTrainMutation = useUpdateTrain(currentWork ?? "");
 	const deleteTrainMutation = useDeleteTrain(currentWork ?? "");
@@ -567,7 +580,7 @@ export const App = () => {
 	const deleteTimetableRowMutation = useDeleteTimetableRow();
 
 	const [currentLine, setCurrentLine] = useState<string | null>(null);
-	const { data: apiLines } = useLines(projectId ?? "");
+	const { data: apiLines, isLoading: linesLoading } = useLines(projectId ?? "");
 	const createLineMutation = useCreateLine(projectId ?? "");
 	const updateLineMutation = useUpdateLine(projectId ?? "");
 	const deleteLineMutation = useDeleteLine(projectId ?? "");
@@ -577,7 +590,7 @@ export const App = () => {
 	const updateProjectStationMutation = useUpdateProjectStation(projectId ?? "");
 	const deleteProjectStationMutation = useDeleteProjectStation(projectId ?? "");
 
-	const { data: apiColors } = useColors(projectId ?? "");
+	const { data: apiColors, isLoading: colorsLoading } = useColors(projectId ?? "");
 	const createColorMutation = useCreateColor(projectId ?? "");
 	const updateColorMutation = useUpdateColor(projectId ?? "");
 	const deleteColorMutation = useDeleteColor(projectId ?? "");
@@ -1423,6 +1436,7 @@ export const App = () => {
 	const sidebarContent = projectId ? (
 		<SidebarTree
 			project={project}
+			isLoadingWorkGroups={workGroupsLoading}
 			currentScreen={screen}
 			currentWG={currentWG}
 			currentWork={currentWork}
@@ -1573,6 +1587,7 @@ export const App = () => {
 				{projectId && screen === "work" && work ? (
 					<WorkBrowser
 						work={work}
+						isLoadingTrains={trainsLoading}
 						onCreateTrain={handleCreateTrain}
 						onUpdateTrain={handleUpdateTrain}
 						onDeleteTrain={handleDeleteTrain}
@@ -1628,6 +1643,7 @@ export const App = () => {
 				{projectId && screen === "lines" ? (
 					<LineManager
 						lines={modelLines}
+						isLoading={linesLoading}
 						stations={modelProjectStations}
 						stationsOnLine={modelStationsOnLine}
 						stopPatterns={modelStopPatterns}
@@ -1661,6 +1677,7 @@ export const App = () => {
 				{projectId && screen === "colors" ? (
 					<ColorManager
 						colors={apiColors ?? []}
+						isLoading={colorsLoading}
 						onCreate={handleCreateColor}
 						onUpdate={handleUpdateColor}
 						onDelete={handleDeleteColor}

--- a/frontend/src/components/ColorManager.tsx
+++ b/frontend/src/components/ColorManager.tsx
@@ -28,6 +28,7 @@ export type ColorDraft = Omit<Color, "id" | "projectId" | "createdAt">;
 
 type ColorManagerProps = {
 	readonly colors: Color[];
+	readonly isLoading: boolean;
 	readonly onCreate: (draft: ColorDraft) => void;
 	readonly onUpdate: (vars: { id: string } & ColorDraft) => void;
 	readonly onDelete: (id: string) => void;
@@ -44,6 +45,7 @@ const EMPTY: ColorDraft = {
 
 export const ColorManager = ({
 	colors,
+	isLoading,
 	onCreate,
 	onUpdate,
 	onDelete,
@@ -116,7 +118,12 @@ export const ColorManager = ({
 				/>
 			)}
 
-			{colors.length === 0 && editingId === null ? (
+			{isLoading && colors.length === 0 && editingId === null ? (
+				<div className="loading-center">
+					<span className="spinner" />
+					読み込み中...
+				</div>
+			) : colors.length === 0 && editingId === null ? (
 				<p style={{ color: "var(--color-text-muted)", padding: "24px 0" }}>
 					{t.noColors}
 				</p>

--- a/frontend/src/components/LineManager.tsx
+++ b/frontend/src/components/LineManager.tsx
@@ -1916,6 +1916,7 @@ const LineDialog = ({
 /* ─── Main ─── */
 export type LineManagerProps = {
 	readonly lines: Line[];
+	readonly isLoading: boolean;
 	readonly stations: Station[];
 	readonly stationsOnLine: StationOnLine[];
 	readonly stopPatterns: StopPattern[];
@@ -1940,6 +1941,7 @@ export type LineManagerProps = {
 
 export const LineManager = ({
 	lines,
+	isLoading,
 	stations,
 	stationsOnLine,
 	stopPatterns,
@@ -2114,7 +2116,11 @@ export const LineManager = ({
 							}}>
 							路線一覧 ({lines.length})
 						</div>
-						{lines.length === 0 && (
+						{isLoading && lines.length === 0 ? (
+							<div className="loading-center" style={{ padding: "16px 8px" }}>
+								<span className="spinner" />
+							</div>
+						) : lines.length === 0 ? (
 							<div
 								style={{
 									padding: "12px 8px",
@@ -2123,7 +2129,7 @@ export const LineManager = ({
 								}}>
 								路線がありません。
 							</div>
-						)}
+						) : null}
 						{lines.map((l) => {
 							const sc = stationsOnLine.filter(
 								(sol) => sol.lineId === l.id

--- a/frontend/src/components/ProjectList.tsx
+++ b/frontend/src/components/ProjectList.tsx
@@ -104,13 +104,8 @@ export const ProjectListScreen = ({
 				</button>
 			</div>
 			{isLoading && projects.length === 0 ? (
-				<div
-					style={{
-						display: "flex",
-						justifyContent: "center",
-						padding: "40px 0",
-						color: "var(--color-text-muted)",
-					}}>
+				<div className="loading-center">
+					<span className="spinner" />
 					読み込み中...
 				</div>
 			) : null}

--- a/frontend/src/components/StationTrackManager.tsx
+++ b/frontend/src/components/StationTrackManager.tsx
@@ -190,7 +190,9 @@ export const StationTrackManager = ({
 					)}
 
 					{isLoading ? (
-						<p style={{ color: "var(--color-text-muted)" }}>…</p>
+						<div className="loading-center" style={{ padding: "16px 0" }}>
+							<span className="spinner" />
+						</div>
 					) : (tracks ?? []).length === 0 && editingId === null ? (
 						<p
 							style={{

--- a/frontend/src/components/WorkBrowser.tsx
+++ b/frontend/src/components/WorkBrowser.tsx
@@ -495,6 +495,7 @@ const TrainHeaderBar = ({
 
 type TrainListPanelProps = {
 	readonly trains: Train[];
+	readonly isLoadingTrains: boolean;
 	readonly selectedId: string | null;
 	readonly onSelect: (id: string) => void;
 	readonly onAdd: () => void;
@@ -504,6 +505,7 @@ type TrainListPanelProps = {
 
 const TrainListPanel = ({
 	trains,
+	isLoadingTrains,
 	selectedId,
 	onSelect,
 	onAdd,
@@ -545,7 +547,12 @@ const TrainListPanel = ({
 				</button>
 			</div>
 			<div style={{ flex: 1, overflow: "auto" }}>
-				{trains.length === 0 ? (
+				{isLoadingTrains && trains.length === 0 ? (
+					<div className="loading-center">
+						<span className="spinner" />
+						読み込み中...
+					</div>
+				) : trains.length === 0 ? (
 					<div
 						className="empty-state"
 						style={{ padding: "40px 16px" }}>
@@ -658,6 +665,7 @@ const TrainListPanel = ({
 
 type WorkBrowserProps = {
 	readonly work: Work;
+	readonly isLoadingTrains: boolean;
 	readonly onCreateTrain: (draft: EntityTrainDraft) => void;
 	readonly onUpdateTrain: (vars: EntityTrainUpdate) => void;
 	readonly onDeleteTrain: (id: string) => void;
@@ -686,6 +694,7 @@ type WorkBrowserProps = {
 
 export const WorkBrowser = ({
 	work,
+	isLoadingTrains,
 	onCreateTrain,
 	onUpdateTrain,
 	onDeleteTrain,
@@ -768,6 +777,7 @@ export const WorkBrowser = ({
 			}}>
 			<TrainListPanel
 				trains={work.trains}
+				isLoadingTrains={isLoadingTrains}
 				selectedId={selectedTrainId}
 				onSelect={selectTrain}
 				onAdd={addTrain}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -245,6 +245,21 @@ input, select, textarea { font-family: var(--font-main); }
 .empty-state p { font-size: 13px; max-width: 280px; line-height: 1.6; }
 .section-title { font-size: 13px; font-weight: 600; color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 8px; }
 
+/* Loading spinner */
+@keyframes spin { to { transform: rotate(360deg); } }
+.spinner {
+  width: 18px; height: 18px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-accent);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+.loading-center {
+  display: flex; align-items: center; justify-content: center;
+  gap: 10px; padding: 40px 20px; color: var(--color-text-muted); font-size: 13px;
+}
+
 /* responsive */
 @media (max-width: 768px) {
   :root { --sidebar-w: 0px; }


### PR DESCRIPTION
## Summary

Closes #26 — 全体的にローディング表示がない

- Added CSS keyframe `.spinner` + `.loading-center` helper to `global.css` — pure CSS using existing design tokens, no new dependencies
- Replaced the plain "読み込み中..." text in `ProjectListScreen` with the spinner
- Added spinner to `SidebarTree` while workgroups are loading (after project is opened)
- Added `isLoadingTrains` prop to `WorkBrowser` / `TrainListPanel` to show spinner while train list loads
- Added `isLoading` prop to `LineManager` to show spinner in the line list panel
- Added `isLoading` prop to `ColorManager` to show spinner while colors load
- Replaced the "…" placeholder in `StationTrackManager` with the spinner

All loading indicators use `isLoading` (not `isPending` or `isFetching`) so gated queries (e.g. trains before a work is selected) stay silent and do not show perpetual spinners.

## Test plan

- [ ] Open app cold → project list shows spinner then cards
- [ ] Open a project → sidebar shows spinner while workgroups load, then the tree
- [ ] Select a work → train panel shows spinner while trains load
- [ ] Navigate to Lines → spinner appears while lines list loads
- [ ] Navigate to Colors → spinner appears while colors load
- [ ] Drill into a station's track manager → spinner appears while tracks load
- [ ] **Verify no perpetual spinners** on sections not yet selected (e.g. lines spinner does not appear on the work screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)