### PR TITLE
feat(frontend): add client-side search to project list

### DIFF
--- a/frontend/src/components/ProjectList.tsx
+++ b/frontend/src/components/ProjectList.tsx
@@ -41,7 +41,16 @@ export const ProjectListScreen = ({
 	t,
 }: ProjectListScreenProps) => {
 	const [menu, setMenu] = useState<MenuState | null>(null);
+	const [searchQuery, setSearchQuery] = useState("");
 	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const filteredProjects = searchQuery
+		? projects.filter(
+				(p) =>
+					p.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+					p.description.toLowerCase().includes(searchQuery.toLowerCase())
+			)
+		: projects;
 
 	const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const file = e.target.files?.[0];
@@ -75,7 +84,9 @@ export const ProjectListScreen = ({
 					{t.projects}
 				</h1>
 				<span style={{ fontSize: 13, color: "var(--color-text-muted)" }}>
-					{projects.length} 件
+					{searchQuery
+						? `${filteredProjects.length} / ${projects.length} 件`
+						: `${projects.length} 件`}
 				</span>
 				<div style={{ flex: 1 }} />
 				<input
@@ -102,6 +113,26 @@ export const ProjectListScreen = ({
 					onClick={onNew}>
 					＋ {t.newProject}
 				</button>
+			</div>
+			<div style={{ marginBottom: 16 }}>
+				<input
+					type="search"
+					placeholder={t.search}
+					value={searchQuery}
+					onChange={(e) => {
+						setSearchQuery(e.target.value);
+					}}
+					style={{
+						width: "100%",
+						padding: "8px 12px",
+						fontSize: 14,
+						border: "1px solid var(--color-border)",
+						borderRadius: 6,
+						background: "var(--color-bg-input, var(--color-bg))",
+						color: "var(--color-text)",
+						boxSizing: "border-box",
+					}}
+				/>
 			</div>
 			{isLoading && projects.length === 0 ? (
 				<div
@@ -140,7 +171,7 @@ export const ProjectListScreen = ({
 				<div
 					className="card-grid"
 					style={{ padding: 0 }}>
-					{projects.map((p) => (
+					{filteredProjects.map((p) => (
 						<div
 							key={p.id}
 							className="card project-card"


### PR DESCRIPTION
## Summary

- Adds a full-width search input below the project list header
- Filters projects client-side by name **and** description (case-insensitive)
- Count badge shows `N / M 件` when a query is active, so users can see how many matched vs total
- Uses the existing `t.search` i18n string (both ja/en already had the key)

## Why client-side, no backend changes

`useProjects` already calls `fetchAllPages()` which loads all projects into memory. Server-side search would add backend complexity with no practical benefit for a list that's already fully loaded.

## Test plan

- [ ] Open the project list — search input appears below the header
- [ ] Type a partial project name — only matching cards are shown; count updates to `N / M 件`
- [ ] Type a substring that matches a description but not a name — matches appear
- [ ] Clear the search (native × button or backspace) — all projects return, count shows `M 件`
- [ ] Search with no matches — empty grid (＋ card still present)
- [ ] Verify both ja and en locales show the correct placeholder

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)