### PR TITLE
feat: add QR code / TRViS app-link share dialog (closes #34)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2026,6 +2026,79 @@
                 ]
             }
         },
+        "/projects/{projectId}/trvis": {
+            "get": {
+                "tags": [
+                    "project"
+                ],
+                "summary": "TRViS ネイティブ形式でダウンロードする",
+                "description": "Project の全グラフを TRViS アプリが読み込める JSON 形式 (WorkGroup[]) で返す。\n\n`trvis://app/open/json?path=<このエンドポイントのURL>` の形式でアプリリンクを構成することで、TRViS アプリから直接開くことができる。\n\nこのProjectへのREAD権限が必要です。",
+                "operationId": "downloadProjectForTRViS",
+                "parameters": [
+                    {
+                        "name": "projectId",
+                        "in": "path",
+                        "description": "ProjectのID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "取得成功",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "description": "TRViS ネイティブ形式の WorkGroup 配列",
+                                    "items": {
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "リクエストが不正 (Projectが大きすぎる等)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorData"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "認証トークンのエラー",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorData"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "コンテンツが存在しない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorData"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
         "/projects/import": {
             "post": {
                 "tags": [

--- a/backend/src/trvis_backend/api/ProjectApi.php
+++ b/backend/src/trvis_backend/api/ProjectApi.php
@@ -100,6 +100,13 @@ class ProjectApi
 				'name' => 'exportProject',
 			],
 			[
+				'methods' => ['GET'],
+				'basePath' => '/api/v1',
+				'path' => '/projects/{projectId}/trvis',
+				'handler' => [self::class, 'downloadProjectForTRViS'],
+				'name' => 'downloadProjectForTRViS',
+			],
+			[
 				'methods' => ['PUT'],
 				'basePath' => '/api/v1',
 				'path' => '/projects/{projectId}',
@@ -374,6 +381,68 @@ class ProjectApi
 		}
 
 		return $this->transferService->export(
+			projectsId: Uuid::fromString($projectId),
+			userId: $userId,
+		)->getResponseWithJson($response);
+	}
+
+	#[OA\Get(
+		path: '/projects/{projectId}/trvis',
+		operationId: 'downloadProjectForTRViS',
+		tags: ['project'],
+		summary: 'TRViS ネイティブ形式でダウンロードする',
+		description: "Project の全グラフを TRViS アプリが読み込める JSON 形式 (WorkGroup[]) で返す。\n\n`trvis://app/open/json?path=<このエンドポイントのURL>` の形式でアプリリンクを構成することで、TRViS アプリから直接開くことができる。\n\nこのProjectへのREAD権限が必要です。",
+		security: [['bearerAuth' => []]],
+		parameters: [
+			new OA\PathParameter(
+				name: 'projectId',
+				description: 'ProjectのID',
+				required: true,
+				schema: new OA\Schema(type: 'string', format: 'uuid'),
+			),
+		],
+		responses: [
+			new OA\Response(
+				response: 200,
+				description: '取得成功',
+				content: new OA\MediaType(
+					mediaType: 'application/json',
+					schema: new OA\Schema(
+						type: 'array',
+						description: 'TRViS ネイティブ形式の WorkGroup 配列',
+						items: new OA\Schema(type: 'object'),
+					),
+				),
+			),
+			new OA\Response(
+				response: 400,
+				description: 'リクエストが不正 (Projectが大きすぎる等)',
+				content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorData'),
+			),
+			new OA\Response(
+				response: 401,
+				description: '認証トークンのエラー',
+				content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorData'),
+			),
+			new OA\Response(
+				response: 404,
+				description: 'コンテンツが存在しない',
+				content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorData'),
+			),
+		],
+	)]
+	public function downloadProjectForTRViS(
+		ServerRequestInterface $request,
+		ResponseInterface $response,
+		string $projectId
+	): ResponseInterface {
+		$userId = MyAuthMiddleware::getUserIdOrAnonymous($request);
+		if (!Uuid::isValid($projectId)) {
+			$this->logger->warning("Invalid UUID format ({projectId})", ['projectId' => $projectId]);
+			return Utils::withUuidError($response);
+		}
+
+		return $this->transferService->downloadForTRViS(
 			projectsId: Uuid::fromString($projectId),
 			userId: $userId,
 		)->getResponseWithJson($response);

--- a/backend/src/trvis_backend/service/ProjectTransferService.php
+++ b/backend/src/trvis_backend/service/ProjectTransferService.php
@@ -220,6 +220,169 @@ final class ProjectTransferService
 		return $list;
 	}
 
+	// ───────────────────────── TRViS DOWNLOAD ────────────────────────
+
+	/**
+	 * Build the TRViS-native WorkGroup[] JSON from the project graph.
+	 *
+	 * The TRViS app (`trvis://app/open/json?path=…`) fetches this endpoint and
+	 * loads the result directly into its timetable viewer. The format is a flat
+	 * JSON array of WorkGroup objects (nested: WorkGroup → Works → Trains →
+	 * TimetableRows) with field names matching TRViS's JsonModels namespace.
+	 *
+	 * Station names and marker colours are resolved from the graph so the app
+	 * never needs to follow FK references.
+	 *
+	 * @return RetValueOrError<array<int,array<string,mixed>>>
+	 */
+	public function downloadForTRViS(
+		UuidInterface $projectsId,
+		string $userId,
+	): RetValueOrError {
+		$this->logger->debug(
+			"downloadForTRViS(projectsId:{projectsId}, userId:{userId})",
+			['projectsId' => $projectsId, 'userId' => $userId],
+		);
+
+		$exportResult = $this->export($projectsId, $userId);
+		if ($exportResult->isError) {
+			return $exportResult;
+		}
+		$graph = $exportResult->value;
+
+		// Build O(1) lookup maps keyed by UUID string.
+		$stationMap = [];
+		foreach ($graph['stations'] as $s) {
+			$stationMap[(string)$s->stations_id] = $s;
+		}
+		$colorMap = [];
+		foreach ($graph['colors'] as $c) {
+			$colorMap[(string)$c->colors_id] = $c;
+		}
+
+		// Inverted indexes for hierarchical grouping.
+		$worksByWgId = [];
+		foreach ($graph['works'] as $w) {
+			$worksByWgId[(string)$w->work_groups_id][] = $w;
+		}
+		$trainsByWorkId = [];
+		foreach ($graph['trains'] as $t) {
+			$trainsByWorkId[(string)$t->works_id][] = $t;
+		}
+		$rowsByTrainId = [];
+		foreach ($graph['timetable_rows'] as $r) {
+			$rowsByTrainId[(string)$r->trains_id][] = $r;
+		}
+
+		$trvisData = [];
+		foreach ($graph['work_groups'] as $wg) {
+			$wgId = (string)$wg->work_groups_id;
+			$trvisWg = ['Name' => $wg->name, 'DBVersion' => 0, 'Works' => []];
+
+			foreach ($worksByWgId[$wgId] ?? [] as $w) {
+				$workId = (string)$w->works_id;
+				$affectDate = $w->affect_date?->format('Ymd');
+				$trvisWork = [
+					'Name' => $w->name,
+					'AffectDate' => $affectDate,
+					'Remarks' => $w->remarks,
+					'Trains' => [],
+				];
+
+				foreach ($trainsByWorkId[$workId] ?? [] as $t) {
+					$trainId = (string)$t->trains_id;
+					$trvisTrain = [
+						'TrainNumber' => $t->train_number,
+						'Direction' => $t->direction,
+						'MaxSpeed' => $t->max_speed,
+						'SpeedType' => $t->speed_type,
+						'CarCount' => $t->car_count,
+						'Destination' => $t->destination,
+						'BeginRemarks' => $t->begin_remarks,
+						'AfterRemarks' => $t->after_remarks,
+						'BeforeDeparture' => $t->before_departure,
+						'AfterArrive' => $t->after_arrive,
+						'Remarks' => $t->remarks,
+						'NominalTractiveCapacity' => $t->nominal_tractive_capacity,
+						'DayCount' => $t->day_count,
+						'TrainInfo' => $t->train_info,
+						'TimetableRows' => [],
+					];
+
+					foreach ($rowsByTrainId[$trainId] ?? [] as $r) {
+						$stId = $r->stations_id !== null ? (string)$r->stations_id : '';
+						$station = $stationMap[$stId] ?? null;
+						$locationM = $station !== null
+							? (float)$station->location_km * 1000.0
+							: null;
+						$lon = $station?->location_lonlat?->longitude;
+						$lat = $station?->location_lonlat?->latitude;
+
+						$markerColor = null;
+						if ($r->colors_id_marker !== null) {
+							$c = $colorMap[(string)$r->colors_id_marker] ?? null;
+							$c8 = $c?->color_8bit;
+							if ($c8 !== null) {
+								$markerColor = sprintf(
+									'%02X%02X%02X',
+									(int)$c8->red,
+									(int)$c8->green,
+									(int)$c8->blue,
+								);
+							}
+						}
+
+						$trvisTrain['TimetableRows'][] = [
+							'StationName' => $r->stations_name ?? '',
+							'Location_m' => $locationM,
+							'Longitude_deg' => $lon,
+							'Latitude_deg' => $lat,
+							'Arrive' => $this->formatTime(
+								$r->arrive_time_hh,
+								$r->arrive_time_mm,
+								$r->arrive_time_ss,
+							),
+							'Departure' => $this->formatTime(
+								$r->departure_time_hh,
+								$r->departure_time_mm,
+								$r->departure_time_ss,
+							),
+							'DriveTime_MM' => $r->drive_time_mm,
+							'DriveTime_SS' => $r->drive_time_ss,
+							'IsOperationOnlyStop' => $r->is_operation_only_stop,
+							'IsPass' => $r->is_pass,
+							'HasBracket' => $r->has_bracket,
+							'IsLastStop' => $r->is_last_stop,
+							'RunInLimit' => $r->run_in_limit,
+							'RunOutLimit' => $r->run_out_limit,
+							'Remarks' => $r->remarks,
+							'MarkerColor' => $markerColor,
+							'MarkerText' => $r->marker_text,
+							'TrackName' => $r->station_tracks_name,
+						];
+					}
+
+					$trvisWork['Trains'][] = $trvisTrain;
+				}
+
+				$trvisWg['Works'][] = $trvisWork;
+			}
+
+			$trvisData[] = $trvisWg;
+		}
+
+		return RetValueOrError::withValue($trvisData);
+	}
+
+	/** Format H/M/S components as "HH:MM:SS"; returns null when all are null. */
+	private function formatTime(?int $hh, ?int $mm, ?int $ss): ?string
+	{
+		if ($hh === null && $mm === null && $ss === null) {
+			return null;
+		}
+		return sprintf('%02d:%02d:%02d', $hh ?? 0, $mm ?? 0, $ss ?? 0);
+	}
+
 	// ───────────────────────────── IMPORT ─────────────────────────────
 
 	/**

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
 		"i18next-browser-languagedetector": "^8.2.1",
 		"i18next-http-backend": "^4.0.0",
 		"openapi-fetch": "0.17.0",
+		"qrcode.react": "^4.2.0",
 		"react": "^19.2.6",
 		"react-dom": "^19.2.6",
 		"react-hook-form": "^7.76.1",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -33,6 +33,16 @@ export class ApiError extends Error {
 const rawBase = import.meta.env.VITE_API_BASE_URL ?? "/api/v1";
 const baseUrl = rawBase.replace(/\/+$/, "");
 
+/**
+ * Absolute base URL for the API (resolves relative VITE_API_BASE_URL against
+ * window.location.origin so QR-code / app-link generators can build full URLs).
+ */
+export function getAbsoluteApiBase(): string {
+	return rawBase.startsWith("http")
+		? baseUrl
+		: window.location.origin + baseUrl;
+}
+
 export const getCurrentIdToken = async (): Promise<string> => {
 	const u = auth.currentUser;
 	if (u === null) return "";

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -331,6 +331,26 @@ export type paths = {
 		patch?: never;
 		trace?: never;
 	};
+	"/projects/{projectId}/trvis": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * TRViS ネイティブ形式でダウンロードする
+		 * @description Project の全グラフを TRViS アプリが読み込める JSON 形式 (WorkGroup[]) で返す。
+		 */
+		get: operations["downloadProjectForTRViS"];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 	"/projects/import": {
 		parameters: {
 			query?: never;
@@ -5871,6 +5891,48 @@ export type operations = {
 			};
 			/** @description 許可されていない操作を行おうとした */
 			403: {
+				headers: Record<string, unknown>;
+				content: {
+					"application/json": components["schemas"]["ApiErrorData"];
+				};
+			};
+			/** @description コンテンツが存在しない */
+			404: {
+				headers: Record<string, unknown>;
+				content: {
+					"application/json": components["schemas"]["ApiErrorData"];
+				};
+			};
+		};
+	};
+	downloadProjectForTRViS: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				/** @description ProjectのID */
+				projectId: string;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description 取得成功 */
+			200: {
+				headers: Record<string, unknown>;
+				content: {
+					"application/json": Record<string, unknown>[];
+				};
+			};
+			/** @description リクエストが不正 (Projectが大きすぎる等) */
+			400: {
+				headers: Record<string, unknown>;
+				content: {
+					"application/json": components["schemas"]["ApiErrorData"];
+				};
+			};
+			/** @description 認証トークンのエラー */
+			401: {
 				headers: Record<string, unknown>;
 				content: {
 					"application/json": components["schemas"]["ApiErrorData"];

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -95,6 +95,7 @@ import {
 import { LineManager } from "../components/LineManager";
 import { ProjectListScreen } from "../components/ProjectList";
 import { StopPatternWizard } from "../components/StopPatternWizard";
+import { TRViSShareDialog } from "../components/TRViSShareDialog";
 import { WorkBrowser } from "../components/WorkBrowser";
 import AuthControls from "../components/auth/AuthControls";
 
@@ -623,6 +624,7 @@ export const App = () => {
 	} | null>(null);
 	const [confirmDialog, setConfirmDialog] = useState<ConfirmState | null>(null);
 	const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+	const [shareProjectId, setShareProjectId] = useState<string | null>(null);
 
 	const baseProject = apiProjects?.find((p) => p.id === projectId);
 
@@ -1567,6 +1569,9 @@ export const App = () => {
 						onExport={(pid) =>
 							pid !== undefined ? exportProject(pid) : exportAll()
 						}
+						onShare={(pid) => {
+							setShareProjectId(pid);
+						}}
 						t={t}
 					/>
 				)}
@@ -1739,6 +1744,18 @@ export const App = () => {
 					onClose={() => {
 						setContextMenu(null);
 					}}
+				/>
+			) : null}
+			{shareProjectId !== null ? (
+				<TRViSShareDialog
+					projectId={shareProjectId}
+					projectName={
+						apiProjects?.find((p) => p.id === shareProjectId)?.name ?? shareProjectId
+					}
+					onClose={() => {
+						setShareProjectId(null);
+					}}
+					t={t}
 				/>
 			) : null}
 		</div>

--- a/frontend/src/components/ProjectList.tsx
+++ b/frontend/src/components/ProjectList.tsx
@@ -24,6 +24,7 @@ type ProjectListScreenProps = {
 	readonly onDelete: (p: Project) => void;
 	readonly onImport: (json: unknown) => void;
 	readonly onExport: (id?: string) => void;
+	readonly onShare: (id: string) => void;
 	readonly t: Strings;
 };
 
@@ -38,6 +39,7 @@ export const ProjectListScreen = ({
 	onDelete,
 	onImport,
 	onExport,
+	onShare,
 	t,
 }: ProjectListScreenProps) => {
 	const [menu, setMenu] = useState<MenuState | null>(null);
@@ -250,6 +252,13 @@ export const ProjectListScreen = ({
 							label: "JSONとしてエクスポート",
 							onClick: () => {
 								onExport(menu.project.id);
+							},
+						},
+						{
+							icon: "📱",
+							label: t.qrCode,
+							onClick: () => {
+								onShare(menu.project.id);
 							},
 						},
 						{

--- a/frontend/src/components/TRViSShareDialog.tsx
+++ b/frontend/src/components/TRViSShareDialog.tsx
@@ -1,0 +1,155 @@
+import { useState } from "react";
+
+import { QRCodeSVG } from "qrcode.react";
+
+import { getAbsoluteApiBase } from "../api/client";
+
+import type { Strings } from "../i18n/strings";
+
+type TRViSShareDialogProps = {
+	readonly projectId: string;
+	readonly projectName: string;
+	readonly onClose: () => void;
+	readonly t: Strings;
+};
+
+export const TRViSShareDialog = ({
+	projectId,
+	projectName,
+	onClose,
+	t,
+}: TRViSShareDialogProps) => {
+	const [copied, setCopied] = useState(false);
+
+	const downloadUrl = `${getAbsoluteApiBase()}/projects/${projectId}/trvis`;
+	const trvisLink = `trvis://app/open/json?path=${encodeURIComponent(downloadUrl)}`;
+
+	const handleCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(downloadUrl);
+			setCopied(true);
+			setTimeout(() => {
+				setCopied(false);
+			}, 2000);
+		} catch {
+			// fallback: select the text
+		}
+	};
+
+	return (
+		<div
+			style={{
+				position: "fixed",
+				inset: 0,
+				background: "rgba(0,0,0,0.5)",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				zIndex: 1000,
+			}}
+			onClick={onClose}>
+			<div
+				style={{
+					background: "var(--color-surface)",
+					borderRadius: 12,
+					padding: "24px 28px",
+					minWidth: 320,
+					maxWidth: 420,
+					width: "90vw",
+					boxShadow: "0 8px 32px rgba(0,0,0,0.18)",
+				}}
+				onClick={(e) => {
+					e.stopPropagation();
+				}}>
+				<div
+					style={{
+						display: "flex",
+						alignItems: "center",
+						marginBottom: 20,
+						gap: 8,
+					}}>
+					<h2
+						style={{
+							flex: 1,
+							fontSize: 18,
+							fontWeight: 700,
+						}}>
+						{t.qrCodeTitle}
+					</h2>
+					<button
+						type="button"
+						className="btn btn-ghost btn-xs"
+						onClick={onClose}
+						aria-label="閉じる"
+						style={{ fontSize: 18 }}>
+						✕
+					</button>
+				</div>
+
+				<p
+					style={{
+						fontSize: 14,
+						color: "var(--color-text-muted)",
+						marginBottom: 16,
+					}}>
+					{projectName}
+				</p>
+
+				<div
+					style={{
+						display: "flex",
+						justifyContent: "center",
+						marginBottom: 20,
+						padding: 12,
+						background: "#fff",
+						borderRadius: 8,
+					}}>
+					<QRCodeSVG
+						value={trvisLink}
+						size={200}
+						level="M"
+					/>
+				</div>
+
+				<p
+					style={{
+						fontSize: 12,
+						color: "var(--color-text-muted)",
+						marginBottom: 16,
+						lineHeight: 1.5,
+					}}>
+					{t.trvisNoteAnon}
+				</p>
+
+				<div
+					style={{
+						display: "flex",
+						gap: 8,
+						marginBottom: 12,
+					}}>
+					<a
+						href={trvisLink}
+						className="btn btn-primary btn-sm"
+						style={{
+							flex: 1,
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							gap: 6,
+							textDecoration: "none",
+						}}>
+						{"📱 "}
+						{t.openInTRViS}
+					</a>
+					<button
+						type="button"
+						className="btn btn-secondary btn-sm"
+						onClick={handleCopy}
+						style={{ flex: 1 }}>
+						{copied ? `✓ ${t.copied}` : `📋 ${t.copyUrl}`}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/frontend/src/i18n/strings.ts
+++ b/frontend/src/i18n/strings.ts
@@ -86,6 +86,12 @@ export const TRVIS_I18N = {
 		noTracks: "番線がありません。",
 		deleted: "削除済み",
 		none: "なし",
+		openInTRViS: "TRViSで開く",
+		qrCode: "QRコード表示",
+		qrCodeTitle: "TRViS QRコード",
+		copyUrl: "URLをコピー",
+		copied: "コピーしました",
+		trvisNoteAnon: "このプロジェクトへの読み取りアクセスがあるユーザーのみ、TRViSから開けます。",
 	},
 	en: {
 		appName: "TRViS Editor",
@@ -172,6 +178,12 @@ export const TRVIS_I18N = {
 		noTracks: "No tracks yet.",
 		deleted: "deleted",
 		none: "none",
+		openInTRViS: "Open in TRViS",
+		qrCode: "Show QR Code",
+		qrCodeTitle: "TRViS QR Code",
+		copyUrl: "Copy URL",
+		copied: "Copied!",
+		trvisNoteAnon: "Only users with read access to this project can open it in TRViS.",
 	},
 } as const;
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6728,6 +6728,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qrcode.react@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "qrcode.react@npm:4.2.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/68c691d130e5fda2f57cee505ed7aea840e7d02033100687b764601f9595e1116e34c13876628a93e1a5c2b85e4efc27d30b2fda72e2050c02f3e1c4e998d248
+  languageName: node
+  linkType: hard
+
 "queue-tick@npm:^1.0.1":
   version: 1.0.1
   resolution: "queue-tick@npm:1.0.1"
@@ -8300,6 +8309,7 @@ __metadata:
     openapi-fetch: "npm:0.17.0"
     openapi-typescript: "npm:7.13.0"
     prettier: "npm:^3.8.3"
+    qrcode.react: "npm:^4.2.0"
     react: "npm:^19.2.6"
     react-dom: "npm:^19.2.6"
     react-hook-form: "npm:^7.76.1"


### PR DESCRIPTION
## Summary

- **Backend**: new `GET /projects/{projectId}/trvis` endpoint returns TRViS-native `WorkGroup[]` JSON by transforming the existing export graph in O(n) via inverted-index maps
  - Station names are already resolved by `TimetableRowsRepo` JOINs; times formatted as `"HH:MM:SS"`, dates as `"YYYYMMDD"`, marker colours as 6-char hex (no `#`)
  - Privilege check reuses `export()` which passes `includeAnonymous: true`, so anonymous requests succeed on projects that have a public read privilege row
- **Frontend**: `TRViSShareDialog` modal shows a QR code for the deep-link `trvis://app/open/json?path=<endpoint-url>`, an "Open in TRViS" anchor button, and a clipboard copy button with 2 s feedback
  - Wired into `ProjectListScreen` via a new "QRコード表示" context-menu item
  - `getAbsoluteApiBase()` resolves relative `VITE_API_BASE_URL` to a full URL so QR codes work even when the API base is a path-only config
  - Added `qrcode.react` v4.2.0 for `QRCodeSVG`
  - i18n strings added in both `ja` and `en`

## Test plan

- [ ] Right-click a project card → "QRコード表示" → dialog opens with QR code and buttons
- [ ] "TRViSで開く" button opens `trvis://...` deep-link (on a device with TRViS installed)
- [ ] "URLをコピー" copies the bare download URL to clipboard; button shows "✓ コピーしました" for 2 s
- [ ] `GET /api/v1/projects/{id}/trvis` returns valid `WorkGroup[]` JSON matching the TRViS format
- [ ] Anonymous fetch works for a project with public read privilege; returns 404 otherwise
- [ ] TypeScript: `yarn tsc --noEmit` passes with no errors

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)