### PR TITLE
fix(backend): fix 500 error when creating stop pattern rows (issue #31)

### DIFF
--- a/backend/src/trvis_backend/service/StopPatternRowsService.php
+++ b/backend/src/trvis_backend/service/StopPatternRowsService.php
@@ -75,6 +75,13 @@ final class StopPatternRowsService
 		return RetValueOrError::withValue(Uuid::fromBytes($row['projects_id']));
 	}
 
+	/** Coerce a request value (string UUID, or UuidInterface from a direct
+	 *  test caller) into a UuidInterface. */
+	private static function asUuid(mixed $v): UuidInterface
+	{
+		return $v instanceof UuidInterface ? $v : Uuid::fromString((string)$v);
+	}
+
 	/**
 	 * @return RetValueOrError<array<\dev_t0r\trvis_backend\model\StopPatternRow>>
 	 */
@@ -129,7 +136,8 @@ final class StopPatternRowsService
 					stopPatternRowId: $rowId,
 					stopPatternsId: $stopPatternsId,
 					owner: $userId,
-					projectStationsId: $d->project_stations_id,
+					// HTTP body delivers project_stations_id as a string; repo expects UuidInterface.
+					projectStationsId: self::asUuid($d->project_stations_id),
 					sortKey: $d->sort_key ?? 0,
 					trackName: $d->track_name,
 					trackHidden: $d->track_hidden ?? false,


### PR DESCRIPTION
## Summary

- `POST /stop_patterns/{id}/rows` always returned HTTP 500 due to a `TypeError` in `StopPatternRowsService::create()`
- The JSON body delivers `project_stations_id` as a plain string, but `StopPatternRowsRepo::insertStopPatternRow()` declares its 4th argument as `UuidInterface` — no conversion was happening before the call
- Added an `asUuid()` helper (identical to the one already present in `StopPatternsService` that fixed the same bug for `lines_id`) and applied it at the call site

## Root cause (from logs)

```
Failed to create stop pattern row: TypeError: insertStopPatternRow(): Argument #4 ($projectStationsId) must be of type Ramsey\Uuid\UuidInterface, string given, called in StopPatternRowsService.php on line 128
```

This is the same class of bug that was fixed for `lines_id` in `StopPatternsService` — the HTTP body parser hands parsed JSON values to the service as raw PHP scalars, but the repo layer expects `UuidInterface`.

## Changes

- `backend/src/trvis_backend/service/StopPatternRowsService.php`
  - Added `private static function asUuid(mixed $v): UuidInterface` helper
  - Changed `projectStationsId: $d->project_stations_id` → `projectStationsId: self::asUuid($d->project_stations_id)`

## Test plan

- [ ] Create a stop pattern via `POST /projects/{id}/lines/{lineId}/stop_patterns`
- [ ] Create stop pattern rows via `POST /stop_patterns/{id}/rows` — should now return 201 instead of 500
- [ ] Verify `GET /stop_patterns/{id}/rows` returns the created rows

Fixes #31.