### PR TITLE
fix(docker): add vendor/.gitkeep so runc can mount named volume over …

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,7 +1,8 @@
 # ref: https://github.com/github/gitignore/blob/master/Composer.gitignore
 
 composer.phar
-/vendor/
+/vendor/*
+!/vendor/.gitkeep
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file


### PR DESCRIPTION
…read-only bind

Newer runc versions try to create the /var/www/html/vendor mountpoint after the read-only bind mount is already applied, causing mkdirat to fail with "read-only file system". Having vendor/ present in the host bind-mount source avoids the mkdir entirely.