### PR TITLE
fix(frontend): ログインエラーが画面に表示されない不具合を修正

### DIFF
--- a/frontend/src/firebase/getAuthErrorMessage.ts
+++ b/frontend/src/firebase/getAuthErrorMessage.ts
@@ -1,5 +1,3 @@
-import { t } from "i18next";
-
 import type { SerializedError } from "@reduxjs/toolkit";
 
 export const getAuthErrorMessage = ({
@@ -7,48 +5,47 @@ export const getAuthErrorMessage = ({
 	code,
 	message,
 }: SerializedError): string => {
-	console.log("getAuthErrorMessage", name, code, message);
 	if (code == null || name == null) {
-		return message ?? name ?? "Unknown error";
+		return message ?? name ?? "不明なエラーが発生しました";
 	}
 
 	switch (code) {
 		case "auth/email-already-in-use":
-			return t("auth.email-already-in-use");
+			return "このメールアドレスはすでに使用されています";
 		case "auth/internal-error":
-			return t("auth.internal-error");
+			return "内部エラーが発生しました";
 		case "auth/invalid-verification-code":
-			return t("auth.invalid-verification-code");
+			return "確認コードが正しくありません";
 		case "auth/invalid-email":
-			return t("auth.invalid-email");
+			return "メールアドレスの形式が正しくありません";
 		case "auth/invalid-credential":
-			return t("auth.invalid-credential");
+			return "メールアドレスまたはパスワードが正しくありません";
 		case "auth/unauthorized-domain":
-			return t("auth.unauthorized-domain");
+			return "このドメインからはサインインできません";
 		case "auth/network-request-failed":
-			return t("auth.network-request-failed");
+			return "ネットワークエラーが発生しました。インターネット接続を確認してください";
 		case "auth/null-user":
-			return t("auth.null-user");
+			return "ユーザー情報が見つかりません";
 		case "auth/operation-not-allowed":
-			return t("auth.operation-not-allowed");
+			return "この操作は許可されていません";
 		case "auth/timeout":
-			return t("auth.timeout");
+			return "タイムアウトしました。再度お試しください";
 		case "auth/user-token-expired":
-			return t("auth.user-token-expired");
+			return "セッションが期限切れです。再度サインインしてください";
 		case "auth/too-many-requests":
-			return t("auth.too-many-requests");
+			return "操作が多すぎます。しばらくしてから再度お試しください";
 		case "auth/unauthorized-continue-uri":
-			return t("auth.unauthorized-continue-uri");
+			return "リダイレクト先が無効です";
 		case "auth/unverified-email":
-			return t("auth.unverified-email");
+			return "メールアドレスの確認が完了していません";
 		case "auth/user-disabled":
-			return t("auth.user-disabled");
+			return "このアカウントは無効化されています";
 		case "auth/user-signed-out":
-			return t("auth.user-signed-out");
+			return "サインアウトしました";
 		case "auth/wrong-password":
 		case "auth/user-not-found":
-			return t("auth.user-not-found");
+			return "メールアドレスまたはパスワードが正しくありません";
 		default:
-			return message ?? name;
+			return message ?? name ?? "不明なエラーが発生しました";
 	}
 };


### PR DESCRIPTION
## 問題

パスワード不正などのログインエラーが画面に表示されない状態になっていた。

## 原因

`getAuthErrorMessage.ts` が `i18next` の `t()` 関数を使ってエラーメッセージを取得しようとしていたが、このアプリは独自の `TRVIS_I18N` システムを採用しており `i18next.init()` を一切呼んでいない。

未初期化の `i18next.t()` は `undefined` を返すか例外を投げるため、`AuthContext` の `catch` ブロック内で `setErrorMessage(undefined)` が呼ばれる（または `setErrorMessage` 自体が呼ばれない）状態となり、エラーが画面に出なかった。

## 修正

`import { t } from "i18next"` を削除し、すべての `t("auth.*")` 呼び出しを日本語ハードコード文字列に置き換えた。

`SignInUpForm.tsx` のバリデーションエラー（例：「メールアドレスを入力してください」）が日本語ハードコードになっているのと同じパターン。

## 変更ファイル

- `frontend/src/firebase/getAuthErrorMessage.ts`
  - `import { t } from "i18next"` 削除
  - デバッグ用 `console.log` 削除
  - 全エラーコードを日本語文字列に置き換え

🤖 Generated with [Claude Code](https://claude.com/claude-code)